### PR TITLE
Remove anko

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     implementation 'org.jetbrains.anko:anko-appcompat-v7:0.10.6'
 
     // Splitties
-    implementation("com.louiscad.splitties:splitties-fun-pack-android-base:3.0.0")
+    implementation("com.louiscad.splitties:splitties-fun-pack-android-appcompat:3.0.0")
 
     //firebase
     implementation platform('com.google.firebase:firebase-bom:31.2.3')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     implementation 'org.jetbrains.anko:anko-support-v4:0.10.6'
     implementation 'org.jetbrains.anko:anko-appcompat-v7:0.10.6'
 
+    // Splitties
+    implementation("com.louiscad.splitties:splitties-fun-pack-android-base:3.0.0")
+
     //firebase
     implementation platform('com.google.firebase:firebase-bom:31.2.3')
     implementation 'com.google.firebase:firebase-database-ktx'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,11 +83,11 @@ dependencies {
     // preference
     implementation("androidx.preference:preference-ktx:1.1.0")
 
+    // coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
+
     //anko
-    implementation 'org.jetbrains.anko:anko-sdk25:0.10.6'
     implementation 'org.jetbrains.anko:anko-sqlite:0.10.6'
-    implementation 'org.jetbrains.anko:anko-support-v4:0.10.6'
-    implementation 'org.jetbrains.anko:anko-appcompat-v7:0.10.6'
 
     // Splitties
     implementation("com.louiscad.splitties:splitties-fun-pack-android-appcompat:3.0.0")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,9 @@ dependencies {
     implementation 'io.github.inflationx:calligraphy3:3.1.1'
     implementation 'io.github.inflationx:viewpump:2.0.3'
 
+    // preference
+    implementation("androidx.preference:preference-ktx:1.1.0")
+
     //anko
     implementation 'org.jetbrains.anko:anko-sdk25:0.10.6'
     implementation 'org.jetbrains.anko:anko-sqlite:0.10.6'

--- a/app/src/main/kotlin/com/jehutyno/yomikata/YomikataZKApplication.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/YomikataZKApplication.kt
@@ -2,6 +2,7 @@ package com.jehutyno.yomikata
 
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.multidex.MultiDexApplication
+import androidx.preference.PreferenceManager
 import com.facebook.stetho.Stetho
 import com.github.salomonbrys.kodein.*
 import com.jehutyno.yomikata.repository.*
@@ -10,7 +11,6 @@ import com.jehutyno.yomikata.util.Prefs
 import io.github.inflationx.calligraphy3.CalligraphyConfig
 import io.github.inflationx.calligraphy3.CalligraphyInterceptor
 import io.github.inflationx.viewpump.ViewPump
-import org.jetbrains.anko.defaultSharedPreferences
 
 
 /**
@@ -37,7 +37,11 @@ class YomikataZKApplication : MultiDexApplication(), KodeinAware {
         super.onCreate()
 
         Stetho.initializeWithDefaults(this)
-        AppCompatDelegate.setDefaultNightMode(defaultSharedPreferences.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
+
+        val nightModePref = PreferenceManager.getDefaultSharedPreferences(this)
+        val mode = nightModePref.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES)
+        AppCompatDelegate.setDefaultNightMode(mode)
+
         ViewPump.init(ViewPump.builder()
                 .addInterceptor(CalligraphyInterceptor(
                         CalligraphyConfig.Builder()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManager.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManager.kt
@@ -5,12 +5,13 @@ import android.content.Context
 import android.media.AudioManager
 import android.net.Uri
 import android.speech.tts.TextToSpeech
+import android.widget.Toast
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.model.Sentence
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.util.*
 import component.ExoPlayerAudio
-import org.jetbrains.anko.toast
+
 
 /**
  * Created by valentinlanfranchi on 01/09/2017.
@@ -23,7 +24,8 @@ class VoicesManager(val context: Activity) {
     fun speakSentence(sentence: Sentence, ttsSupported: Int, tts: TextToSpeech?) {
         val audio = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         if (audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
-            context.toast(context.getString(R.string.message_adjuste_volume))
+            val toast = Toast.makeText(context, R.string.message_adjuste_volume, Toast.LENGTH_LONG)
+            toast.show()
         }
         val speechAvailability = checkSpeechAvailability(context, ttsSupported, sentence.level)
         when (speechAvailability) {
@@ -46,7 +48,8 @@ class VoicesManager(val context: Activity) {
     fun speakWord(word: Word, ttsSupported: Int, tts: TextToSpeech?) {
         val audio = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
         if (audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
-            context.toast(context.getString(R.string.message_adjuste_volume))
+            val toast = Toast.makeText(context, R.string.message_adjuste_volume, Toast.LENGTH_SHORT)
+            toast.show()
         }
         val level = getCategoryLevel(word.baseCategory)
         val speechAvailability = checkSpeechAvailability(context, ttsSupported, level)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -8,10 +8,12 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.app.ActivityCompat
 import androidx.preference.Preference
+import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceFragmentCompat
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.filechooser.FileChooserDialog
@@ -39,7 +41,8 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AppCompatDelegate.setDefaultNightMode(defaultSharedPreferences.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        AppCompatDelegate.setDefaultNightMode(pref.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
         supportFragmentManager.beginTransaction()
                 .replace(android.R.id.content, PrefsFragment()).commit()
     }
@@ -74,7 +77,8 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
             builder.setMessage(R.string.prefs_reinit_sure)
             builder.setPositiveButton(R.string.ok) { _, _ ->
                 CopyUtils.reinitDataBase(activity)
-                requireActivity().toast(R.string.prefs_reinit_done)
+                val toast = Toast.makeText(context, R.string.prefs_reinit_done, Toast.LENGTH_LONG)
+                toast.show()
                 requireActivity().finish()
             }
             builder.setNegativeButton(R.string.cancel_caps) { _, _ -> }
@@ -88,11 +92,14 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
             builder.setMessage(R.string.prefs_delete_voices_sure)
             builder.setPositiveButton(R.string.ok) { _, _ ->
                 FileUtils.deleteFolder(activity, "Voices")
+                val pref = PreferenceManager.getDefaultSharedPreferences(context)
                 for (i in 0 until 7) {
-                    requireActivity().defaultSharedPreferences.edit()
-                            .putBoolean("${Prefs.VOICE_DOWNLOADED_LEVEL_V.pref}${getLevelDownloadVersion(i)}_$i", false).apply()
+                    pref.edit().putBoolean(
+                            "${Prefs.VOICE_DOWNLOADED_LEVEL_V.pref}${getLevelDownloadVersion(i)}_$i", false
+                    ).apply()
                 }
-                requireActivity().toast(getString(R.string.voices_reinit_done))
+                val toast = Toast.makeText(context, R.string.voices_reinit_done, Toast.LENGTH_LONG)
+                toast.show()
                 requireActivity().finish()
             }
             builder.setNegativeButton(R.string.cancel_caps) { _, _ -> }
@@ -162,12 +169,14 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
     }
 
     fun backupProgress() {
-        alert {
-            title = getString(R.string.backup)
-            message = getString(R.string.backup_sure)
-            okButton { CopyUtils.copyEncryptedBddToSd(this@PrefsActivity) }
-            cancelButton { }
-        }.show()
+        val builder = AlertDialog.Builder(this)
+        builder.setTitle(R.string.backup)
+        builder.setMessage(R.string.backup_sure)
+        builder.setPositiveButton(R.string.ok) { _, _ ->
+            CopyUtils.copyEncryptedBddToSd(this@PrefsActivity)
+        }
+        builder.setNegativeButton(R.string.cancel_caps) { _, _ -> }
+        builder.show()
     }
 
     override fun onSelect(path: String?) {
@@ -176,10 +185,10 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
         } else if (path.endsWith(".yomikataz")) {
             importYomikataZ(path)
         } else {
-            alert {
-                title = getString(R.string.use_yomikata_file)
-                okButton { }
-            }.show()
+            val builder = AlertDialog.Builder(this)
+            builder.setTitle(R.string.use_yomikata_file)
+            builder.setPositiveButton(R.string.ok) { _, _ -> }
+            builder.show()
         }
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -122,11 +122,11 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 }
                 "reset" -> {
                     getResetAlert().show()
-                    return super.onPreferenceTreeClick(preference)    // to allow fragment creation
+                    return true
                 }
                 "delete_voices" -> {
                     getDeleteVoicesAlert().show()
-                    return super.onPreferenceTreeClick(preference)
+                    return true
                 }
                 "reset_tuto" -> {
                     PreferencesManager(activity).resetAll()
@@ -141,7 +141,7 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                     return true
                 }
                 else -> {
-                    return true
+                    throw Error("unknown preference key: ${preference.key}")
                 }
             }
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -108,6 +108,26 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
 
         override fun onPreferenceTreeClick(preference: Preference): Boolean {
             when (preference.key) {
+                // Quiz Settings
+                "font_size" -> {
+                    return true
+                }
+                "speed" -> {
+                    return true
+                }
+                "length" -> {
+                    return true
+                }
+
+                // Tutorials
+                "reset_tuto" -> {
+                    PreferencesManager(activity).resetAll()
+                    requireActivity().setResult(RESULT_OK)
+                    requireActivity().finish()
+                    return true
+                }
+
+                // Backup and Restore
                 "backup" -> {
                     if (checkAndRequestPermission()) {
                         (activity as PrefsActivity).backupProgress()
@@ -128,18 +148,15 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                     getDeleteVoicesAlert().show()
                     return true
                 }
-                "reset_tuto" -> {
-                    PreferencesManager(activity).resetAll()
-                    requireActivity().setResult(RESULT_OK)
-                    requireActivity().finish()
-                    return true
-                }
+
+                // Others
                 "privacy" -> {
                     val privacyString = "https://cdn.rawgit.com/jehutyno/privacy-policies/56b6fcf3/PrivacyPolicyYomikataZ.html"
                     val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(privacyString))
                     startActivity(browserIntent)
                     return true
                 }
+
                 else -> {
                     throw Error("unknown preference key: ${preference.key}")
                 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -112,10 +112,19 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 "font_size" -> {
                     return true
                 }
+                "input_change" -> {
+                    return true
+                }
                 "speed" -> {
                     return true
                 }
                 "length" -> {
+                    return true
+                }
+                "play_start" -> {
+                    return true
+                }
+                "play_end" -> {
                     return true
                 }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -1,7 +1,6 @@
 package com.jehutyno.yomikata.screens
 
 import android.Manifest
-import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -27,9 +26,11 @@ import com.jehutyno.yomikata.util.Extras.PERMISSIONS_STORAGE
 import com.jehutyno.yomikata.util.Extras.REQUEST_EXTERNAL_STORAGE_BACKUP
 import com.jehutyno.yomikata.util.Extras.REQUEST_EXTERNAL_STORAGE_RESTORE
 import com.wooplr.spotlight.prefs.PreferencesManager
+import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.MainScope
 import mu.KLogging
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.uiThread
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import splitties.alertdialog.appcompat.*
 import java.io.File
 
@@ -129,7 +130,7 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 }
                 "reset_tuto" -> {
                     PreferencesManager(activity).resetAll()
-                    requireActivity().setResult(Activity.RESULT_OK)
+                    requireActivity().setResult(RESULT_OK)
                     requireActivity().finish()
                     return true
                 }
@@ -208,7 +209,7 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
             progressDialog.setCancelable(false)
             progressDialog.show()
 
-            doAsync {
+            MainScope().async {
                 wordTables.forEach {
                     val wordtable = migrationSource.getWordTable(it)
                     progressDialog.incrementProgressBy(1)
@@ -220,7 +221,7 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 }
                 File(toPath + toName).delete()
 
-                uiThread {
+                withContext(Main) {
                     progressDialog.dismiss()
                     alertDialog {
                         titleResource = R.string.restore_success

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -223,18 +223,18 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 uiThread {
                     progressDialog.dismiss()
                     alertDialog {
-                        title = getString(R.string.restore_success)
-                        okButton { }
-                        message = getString(R.string.restore_success_message)
+                        titleResource = R.string.restore_success
+                        messageResource = R.string.restore_success_message
+                        okButton()
                     }.show()
                 }
 
             }
         } catch (exception: Exception) {
             alertDialog {
-                title = getString(R.string.restore_error)
-                message = getString(R.string.restore_error_message)
-                okButton { }
+                titleResource = R.string.restore_error
+                messageResource = R.string.restore_error_message
+                okButton()
             }.show()
         }
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
@@ -6,6 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate 
 import androidx.appcompat.widget.Toolbar
 import android.view.MenuItem
+import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
 import com.github.salomonbrys.kodein.android.appKodein
@@ -15,7 +16,7 @@ import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.util.Prefs
 import com.jehutyno.yomikata.util.addOrReplaceFragment
 import mu.KLogging
-import org.jetbrains.anko.defaultSharedPreferences
+
 
 /**
  * Created by valentin on 25/10/2016.
@@ -30,7 +31,8 @@ class AnswersActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AppCompatDelegate.setDefaultNightMode(defaultSharedPreferences.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        AppCompatDelegate.setDefaultNightMode(pref.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
         setContentView(R.layout.activity_answers)
 
         if(resources.getBoolean(R.bool.portrait_only)){

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
@@ -26,6 +26,7 @@ class AnswersActivity : AppCompatActivity() {
     companion object : KLogging()
 
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val answersPresenter: AnswersContract.Presenter by injector.instance()
     private lateinit var answersFragment: AnswersFragment
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -22,10 +22,6 @@ import com.jehutyno.yomikata.managers.VoicesManager
 import com.jehutyno.yomikata.model.Answer
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.*
-import org.jetbrains.anko.cancelButton
-import org.jetbrains.anko.okButton
-import org.jetbrains.anko.support.v4.alert
-import org.jetbrains.anko.support.v4.defaultSharedPreferences
 import java.util.*
 
 /**
@@ -127,25 +123,30 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
     }
 
     private fun addSelection(wordId: Long) {
-        alert {
-            title = getString(R.string.new_selection)
-            val input = EditText(activity)
-            input.setSingleLine()
-            input.hint = getString(R.string.selection_name)
-            val container = FrameLayout(requireActivity())
-            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            input.layoutParams = params
-            container.addView(input)
-            customView = container
-            okButton {
-                var selectionId = presenter.createSelection(input.text.toString())
-                presenter.addWordToSelection(wordId, selectionId)
-                presenter.loadSelections()
-            }
-            cancelButton { }
-        }.show()
+        val builder = AlertDialog.Builder(requireActivity())
+        builder.setTitle(R.string.new_selection)
+
+        val input = EditText(activity)
+        input.setSingleLine()
+        input.hint = getString(R.string.selection_name)
+        val container = FrameLayout(requireActivity())
+        val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        input.layoutParams = params
+        container.addView(input)
+
+        builder.setView(input)
+
+        builder.setPositiveButton(R.string.ok) {_, _ ->
+            val selectionId = presenter.createSelection(input.text.toString())
+            presenter.addWordToSelection(wordId, selectionId)
+            presenter.loadSelections()
+        }
+
+        builder.setNegativeButton(R.string.cancel_caps) {_, _ -> }
+
+        builder.show()
     }
 
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -30,6 +30,7 @@ import java.util.*
 class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callback, TextToSpeech.OnInitListener {
 
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val voicesManager: VoicesManager by injector.instance()
     private lateinit var presenter: AnswersContract.Presenter
     private lateinit var layoutManager: LinearLayoutManager

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -142,6 +142,7 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
         requireActivity().alertDialog {
             titleResource = R.string.new_selection
             setView(input)
+
             okButton {
                 val selectionId = presenter.createSelection(input.text.toString())
                 presenter.addWordToSelection(wordId, selectionId)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -1,6 +1,5 @@
 package com.jehutyno.yomikata.screens.answers
 
-import android.app.AlertDialog
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import androidx.fragment.app.Fragment
@@ -22,7 +21,12 @@ import com.jehutyno.yomikata.managers.VoicesManager
 import com.jehutyno.yomikata.model.Answer
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.*
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.cancelButton
+import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.titleResource
 import java.util.*
+
 
 /**
  * Created by valentin on 25/10/2016.
@@ -124,12 +128,10 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
     }
 
     private fun addSelection(wordId: Long) {
-        val builder = AlertDialog.Builder(requireActivity())
-        builder.setTitle(R.string.new_selection)
-
         val input = EditText(activity)
         input.setSingleLine()
         input.hint = getString(R.string.selection_name)
+
         val container = FrameLayout(requireActivity())
         val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
@@ -137,17 +139,16 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
         input.layoutParams = params
         container.addView(input)
 
-        builder.setView(input)
-
-        builder.setPositiveButton(R.string.ok) {_, _ ->
-            val selectionId = presenter.createSelection(input.text.toString())
-            presenter.addWordToSelection(wordId, selectionId)
-            presenter.loadSelections()
-        }
-
-        builder.setNegativeButton(R.string.cancel_caps) {_, _ -> }
-
-        builder.show()
+        requireActivity().alertDialog {
+            titleResource = R.string.new_selection
+            setView(input)
+            okButton {
+                val selectionId = presenter.createSelection(input.text.toString())
+                presenter.addWordToSelection(wordId, selectionId)
+                presenter.loadSelections()
+            }
+            cancelButton()
+        }.show()
     }
 
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
@@ -47,6 +47,7 @@ class ContentActivity : AppCompatActivity() {
 
     private var contentLevelFragment: ContentFragment? = null
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val contentPresenter: ContentContract.Presenter by injector.instance()
 
     private var contentPagerAdapter: ContentPagerAdapter? = null

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
@@ -21,11 +21,7 @@ import com.jehutyno.yomikata.screens.content.word.WordDetailDialogFragment
 import com.jehutyno.yomikata.util.DimensionHelper
 import com.jehutyno.yomikata.util.Extras
 import com.jehutyno.yomikata.util.animateSeekBar
-import org.jetbrains.anko.find
-import splitties.alertdialog.appcompat.alertDialog
-import splitties.alertdialog.appcompat.cancelButton
-import splitties.alertdialog.appcompat.okButton
-import splitties.alertdialog.appcompat.title
+import splitties.alertdialog.appcompat.*
 import java.util.*
 
 
@@ -190,7 +186,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
                     adapter.notifyDataSetChanged()
                 }
                 1 -> {
-                    val popup = PopupMenu(activity!!, activity!!.find(1))
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(1))
                     popup.menuInflater.inflate(R.menu.popup_selections, popup.menu)
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
@@ -214,8 +210,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
                     popup.show()
                 }
                 2 -> {
-
-                    val popup = PopupMenu(activity!!, activity!!.find(2))
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(2))
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
                     }
@@ -243,7 +238,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
 
         private fun addSelection(selectedWords: ArrayList<Word>) {
             requireContext().alertDialog {
-                title = getString(R.string.new_selection)
+                titleResource = R.string.new_selection
                 val input = EditText(activity)
                 input.setSingleLine()
                 input.hint = getString(R.string.selection_name)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
@@ -21,11 +21,11 @@ import com.jehutyno.yomikata.screens.content.word.WordDetailDialogFragment
 import com.jehutyno.yomikata.util.DimensionHelper
 import com.jehutyno.yomikata.util.Extras
 import com.jehutyno.yomikata.util.animateSeekBar
-import org.jetbrains.anko.cancelButton
 import org.jetbrains.anko.find
-import org.jetbrains.anko.okButton
-import org.jetbrains.anko.support.v4.alert
-import org.jetbrains.anko.support.v4.withArguments
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.cancelButton
+import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.title
 import java.util.*
 
 
@@ -59,16 +59,16 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
         super.onCreate(savedInstanceState)
 
         if (arguments != null) {
-            quizIds = arguments!!.getLongArray(Extras.EXTRA_QUIZ_IDS)!!
-            quizTitle = arguments!!.getString(Extras.EXTRA_QUIZ_TITLE)!!
-            level = arguments!!.getInt(Extras.EXTRA_LEVEL, -1)
+            quizIds = requireArguments().getLongArray(Extras.EXTRA_QUIZ_IDS)!!
+            quizTitle = requireArguments().getString(Extras.EXTRA_QUIZ_TITLE)!!
+            level = requireArguments().getInt(Extras.EXTRA_LEVEL, -1)
         }
 
         if (savedInstanceState != null) {
             lastPosition = savedInstanceState.getInt("position")
         }
 
-        adapter = WordsAdapter(activity!!, this)
+        adapter = WordsAdapter(requireActivity(), this)
         setHasOptionsMenu(true)
     }
 
@@ -117,7 +117,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
         super.onViewCreated(view, savedInstanceState)
 
         if (mpresenter == null)
-            mpresenter = ContentPresenter(context!!.appKodein.invoke().instance(), context!!.appKodein.invoke().instance(), this)
+            mpresenter = ContentPresenter(requireContext().appKodein.invoke().instance(), requireContext().appKodein.invoke().instance(), this)
 
         binding.recyclerviewContent.let {
             it.adapter = adapter
@@ -131,18 +131,21 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
 
 
     override fun onItemClick(position: Int) {
-        val dialog = WordDetailDialogFragment().withArguments(
-                Extras.EXTRA_QUIZ_IDS to quizIds,
-                Extras.EXTRA_QUIZ_TITLE to quizTitle,
-                Extras.EXTRA_LEVEL to level,
-                Extras.EXTRA_WORD_POSITION to position,
-                Extras.EXTRA_SEARCH_STRING to "")
+        val bundle = Bundle()
+        bundle.putLongArray(Extras.EXTRA_QUIZ_IDS, quizIds)
+        bundle.putString(Extras.EXTRA_QUIZ_TITLE, quizTitle)
+        bundle.putInt(Extras.EXTRA_LEVEL, level)
+        bundle.putInt(Extras.EXTRA_WORD_POSITION, position)
+        bundle.putString(Extras.EXTRA_SEARCH_STRING, "")
+
+        val dialog = WordDetailDialogFragment()
+        dialog.arguments = bundle
         dialog.show(childFragmentManager, "")
         dialog.isCancelable = true
     }
 
     override fun onCategoryIconClick(position: Int) {
-        activity!!.startActionMode(actionModeCallback)
+        requireActivity().startActionMode(actionModeCallback)
     }
 
     override fun onCheckChange(position: Int, check: Boolean) {
@@ -164,7 +167,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.select_mode ->
-                activity!!.startActionMode(actionModeCallback)
+                requireActivity().startActionMode(actionModeCallback)
         }
         return super.onOptionsItemSelected(item)
     }
@@ -239,7 +242,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
         }
 
         private fun addSelection(selectedWords: ArrayList<Word>) {
-            alert {
+            requireContext().alertDialog {
                 title = getString(R.string.new_selection)
                 val input = EditText(activity)
                 input.setSingleLine()
@@ -250,7 +253,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
                 params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
                 input.layoutParams = params
                 container.addView(input)
-                customView = container
+                setView(container)
                 okButton {
                     val selectionId = mpresenter!!.createSelection(input.text.toString())
                     selectedWords.forEach {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
@@ -237,18 +237,21 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
         }
 
         private fun addSelection(selectedWords: ArrayList<Word>) {
+            val input = EditText(activity)
+            input.setSingleLine()
+            input.hint = getString(R.string.selection_name)
+
+            val container = FrameLayout(requireActivity())
+            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+            input.layoutParams = params
+            container.addView(input)
+
             requireContext().alertDialog {
                 titleResource = R.string.new_selection
-                val input = EditText(activity)
-                input.setSingleLine()
-                input.hint = getString(R.string.selection_name)
-                val container = FrameLayout(requireActivity())
-                val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-                params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-                params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-                input.layoutParams = params
-                container.addView(input)
                 setView(container)
+
                 okButton {
                     val selectionId = mpresenter!!.createSelection(input.text.toString())
                     selectedWords.forEach {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
@@ -1,13 +1,14 @@
 package com.jehutyno.yomikata.screens.content
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.viewpager.widget.PagerAdapter
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.Extras
-import org.jetbrains.anko.support.v4.withArguments
+
 
 /**
  * Created by valentin on 19/12/2016.
@@ -15,7 +16,11 @@ import org.jetbrains.anko.support.v4.withArguments
 class ContentPagerAdapter(val context : Context, fm: FragmentManager, var quizzes: List<Quiz>) : FragmentStatePagerAdapter(fm) {
 
     override fun getItem(position: Int): Fragment {
-        val contentFragment = ContentFragment().withArguments(Extras.EXTRA_QUIZ_IDS to longArrayOf(quizzes[position].id), Extras.EXTRA_QUIZ_TITLE to quizzes[position].getName())
+        val bundle = Bundle()
+        bundle.putLongArray(Extras.EXTRA_QUIZ_IDS, longArrayOf(quizzes[position].id))
+        bundle.putString(Extras.EXTRA_QUIZ_TITLE, quizzes[position].getName())
+        val contentFragment = ContentFragment()
+        contentFragment.arguments = bundle
         return contentFragment
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
@@ -5,19 +5,15 @@ import android.graphics.PorterDuff
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
-import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
-import androidx.core.graphics.BlendModeColorFilterCompat
-import androidx.core.graphics.BlendModeCompat
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.VhWordShortBinding
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.model.getCategoryIcon
 import com.jehutyno.yomikata.model.getWordColor
-import com.jehutyno.yomikata.util.Prefs
-import org.jetbrains.anko.defaultSharedPreferences
+
 
 /**
  * Created by valentin on 04/10/2016.

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
@@ -9,6 +9,8 @@ import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.VhWordShortBinding
 import com.jehutyno.yomikata.model.Word

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
@@ -180,18 +180,21 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
     }
 
     private fun addSelection(wordId: Long) {
+        val input = EditText(activity)
+        input.setSingleLine()
+        input.hint = getString(R.string.selection_name)
+
+        val container = FrameLayout(requireActivity())
+        val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        input.layoutParams = params
+        container.addView(input)
+
         requireContext().alertDialog {
             titleResource = R.string.new_selection
-            val input = EditText(activity)
-            input.setSingleLine()
-            input.hint = getString(R.string.selection_name)
-            val container = FrameLayout(requireActivity())
-            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            input.layoutParams = params
-            container.addView(input)
             setView(container)
+
             okButton {
                 val selectionId = wordPresenter.createSelection(input.text.toString())
                 wordPresenter.addWordToSelection(wordId, selectionId)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
@@ -23,10 +23,7 @@ import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.util.*
 import org.jetbrains.anko.doAsync
 import org.jetbrains.anko.uiThread
-import splitties.alertdialog.appcompat.alertDialog
-import splitties.alertdialog.appcompat.cancelButton
-import splitties.alertdialog.appcompat.okButton
-import splitties.alertdialog.appcompat.title
+import splitties.alertdialog.appcompat.*
 
 /**
  * Created by jehutyno on 08/10/2016.
@@ -179,7 +176,7 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
 
     private fun addSelection(wordId: Long) {
         requireContext().alertDialog {
-            title = getString(R.string.new_selection)
+            titleResource = R.string.new_selection
             val input = EditText(activity)
             input.setSingleLine()
             input.hint = getString(R.string.selection_name)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
@@ -31,7 +31,9 @@ import splitties.alertdialog.appcompat.*
 class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerAdapter.Callback, TextToSpeech.OnInitListener {
 
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val wordPresenter: WordContract.Presenter by injector.instance()
+    @Suppress("unused")
     private val voicesManager: VoicesManager by injector.instance()
     private lateinit var adapter: WordPagerAdapter
     private var wordId: Long = -1

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
@@ -4,14 +4,14 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
-import androidx.fragment.app.DialogFragment
-import androidx.viewpager.widget.ViewPager
-import androidx.appcompat.widget.PopupMenu
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.appcompat.widget.PopupMenu
+import androidx.fragment.app.DialogFragment
+import androidx.viewpager.widget.ViewPager
 import com.github.salomonbrys.kodein.*
 import com.github.salomonbrys.kodein.android.appKodein
 import com.jehutyno.yomikata.R
@@ -21,9 +21,12 @@ import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.model.Sentence
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.util.*
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.uiThread
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import splitties.alertdialog.appcompat.*
+
 
 /**
  * Created by jehutyno on 08/10/2016.
@@ -230,9 +233,11 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
             adapter.words[position].first.level = newLevel
         }
         adapter.words[position].first.points = points
-        doAsync {
-            Thread.sleep(300)
-            uiThread {
+        MainScope().async {
+            withContext(Dispatchers.IO) {
+                Thread.sleep(300)
+            }
+            withContext(Dispatchers.Main) {
                 adapter.notifyDataSetChanged()
             }
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
@@ -21,11 +21,12 @@ import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.model.Sentence
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.util.*
-import org.jetbrains.anko.cancelButton
 import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.okButton
-import org.jetbrains.anko.support.v4.alert
 import org.jetbrains.anko.uiThread
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.cancelButton
+import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.title
 
 /**
  * Created by jehutyno on 08/10/2016.
@@ -75,23 +76,23 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         tts = TextToSpeech(activity, this)
         if (arguments != null) {
-            wordId = arguments!!.getLong(Extras.EXTRA_WORD_ID, -1L)
-            quizType = arguments!!.getSerializable(Extras.EXTRA_QUIZ_TYPE) as QuizType?
-            quizIds = arguments!!.getLongArray(Extras.EXTRA_QUIZ_IDS)
-            quizTitle = arguments!!.getString(Extras.EXTRA_QUIZ_TITLE)
-            wordPosition = arguments!!.getInt(Extras.EXTRA_WORD_POSITION)
-            searchString = arguments!!.getString(Extras.EXTRA_SEARCH_STRING) ?: ""
-            level = arguments!!.getInt(Extras.EXTRA_LEVEL)
+            wordId = requireArguments().getLong(Extras.EXTRA_WORD_ID, -1L)
+            quizType = requireArguments().getSerializable(Extras.EXTRA_QUIZ_TYPE) as QuizType?
+            quizIds = requireArguments().getLongArray(Extras.EXTRA_QUIZ_IDS)
+            quizTitle = requireArguments().getString(Extras.EXTRA_QUIZ_TITLE)
+            wordPosition = requireArguments().getInt(Extras.EXTRA_WORD_POSITION)
+            searchString = requireArguments().getString(Extras.EXTRA_SEARCH_STRING) ?: ""
+            level = requireArguments().getInt(Extras.EXTRA_LEVEL)
         }
 
         if (savedInstanceState != null) {
             wordPosition = savedInstanceState.getInt("position")
         }
 
-        val dialog = Dialog(activity!!, R.style.full_screen_dialog)
+        val dialog = Dialog(requireActivity(), R.style.full_screen_dialog)
         dialog.setContentView(R.layout.dialog_word_detail)
         dialog.setCanceledOnTouchOutside(true)
-        adapter = WordPagerAdapter(activity!!, quizType, this)
+        adapter = WordPagerAdapter(requireActivity(), quizType, this)
         viewPager = dialog.findViewById(R.id.viewpager_words)
         arrowLeft = dialog.findViewById(R.id.arrow_left)
         arrowRight = dialog.findViewById(R.id.arrow_right)
@@ -119,7 +120,7 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
             import(wordPresenterModule(this@WordDetailDialogFragment))
 //            import(voicesManagerModule(activity))
             bind<WordContract.Presenter>() with provider { WordPresenter(instance(), instance(), instance(), instance(), instance()) }
-            bind<VoicesManager>() with singleton { VoicesManager(activity!!) }
+            bind<VoicesManager>() with singleton { VoicesManager(requireActivity()) }
         })
 
         return dialog
@@ -153,7 +154,7 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
     }
 
     override fun onSelectionClick(view: View, position: Int) {
-        val popup = PopupMenu(activity!!, view)
+        val popup = PopupMenu(requireActivity(), view)
         popup.menuInflater.inflate(R.menu.popup_selections, popup.menu)
         for ((i, selection) in selections.withIndex()) {
             popup.menu.add(1, i, i, selection.getName()).isChecked = wordPresenter.isWordInQuiz(adapter.words[position].first.id, selection.id)
@@ -177,18 +178,18 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
     }
 
     private fun addSelection(wordId: Long) {
-        alert {
+        requireContext().alertDialog {
             title = getString(R.string.new_selection)
             val input = EditText(activity)
             input.setSingleLine()
             input.hint = getString(R.string.selection_name)
-            val container = FrameLayout(activity!!)
+            val container = FrameLayout(requireActivity())
             val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
             params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
             params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
             input.layoutParams = params
             container.addView(input)
-            customView = container
+            setView(container)
             okButton {
                 val selectionId = wordPresenter.createSelection(input.text.toString())
                 wordPresenter.addWordToSelection(wordId, selectionId)
@@ -199,7 +200,7 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
     }
 
     override fun onReportClick(position: Int) {
-        reportError(activity!!, adapter.words[position].first, adapter.words[position].third)
+        reportError(requireActivity(), adapter.words[position].first, adapter.words[position].third)
     }
 
     override fun onWordTTSClick(position: Int) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.android.appKodein
 import com.github.salomonbrys.kodein.instance
 import com.google.firebase.database.DataSnapshot
@@ -22,7 +23,6 @@ import com.jehutyno.yomikata.model.StatResult
 import com.jehutyno.yomikata.screens.quizzes.QuizzesActivity
 import com.jehutyno.yomikata.util.*
 
-import org.jetbrains.anko.support.v4.defaultSharedPreferences
 import java.util.*
 
 
@@ -124,8 +124,9 @@ class HomeFragment : Fragment(), HomeContract.View {
     }
 
     fun displayLatestCategories() {
-        val cat1 = defaultSharedPreferences.getInt(Prefs.LATEST_CATEGORY_1.pref, -1)
-        val cat2 = defaultSharedPreferences.getInt(Prefs.LATEST_CATEGORY_2.pref, -1)
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val cat1 = pref.getInt(Prefs.LATEST_CATEGORY_1.pref, -1)
+        val cat2 = pref.getInt(Prefs.LATEST_CATEGORY_2.pref, -1)
 
         if (cat1 != -1) {
             binding.lastCategory1.visibility = VISIBLE

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
@@ -23,6 +23,7 @@ import mu.KLogging
 import splitties.alertdialog.appcompat.alertDialog
 import splitties.alertdialog.appcompat.cancelButton
 import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.titleResource
 
 class QuizActivity : AppCompatActivity() {
 
@@ -100,7 +101,7 @@ class QuizActivity : AppCompatActivity() {
         when (item.itemId) {
             android.R.id.home -> {
                 alertDialog {
-                    title = getString(R.string.quit_quiz)
+                    titleResource = R.string.quit_quiz
                     okButton { finish() }
                     cancelButton()
                 }.show()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import android.view.KeyEvent
 import android.view.MenuItem
+import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
 import com.github.salomonbrys.kodein.android.appKodein
@@ -19,11 +20,9 @@ import com.jehutyno.yomikata.util.QuizStrategy
 import com.jehutyno.yomikata.util.addOrReplaceFragment
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import mu.KLogging
-import org.jetbrains.anko.alert
-import org.jetbrains.anko.defaultSharedPreferences
-import org.jetbrains.anko.noButton
-import org.jetbrains.anko.support.v4.withArguments
-import org.jetbrains.anko.yesButton
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.cancelButton
+import splitties.alertdialog.appcompat.okButton
 
 class QuizActivity : AppCompatActivity() {
 
@@ -43,7 +42,8 @@ class QuizActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AppCompatDelegate.setDefaultNightMode(defaultSharedPreferences.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        AppCompatDelegate.setDefaultNightMode(pref.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
         setContentView(R.layout.activity_quiz)
         if(resources.getBoolean(R.bool.portrait_only)){
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
@@ -67,10 +67,13 @@ class QuizActivity : AppCompatActivity() {
             quizStrategy = intent.getSerializableExtra(Extras.EXTRA_QUIZ_STRATEGY) as QuizStrategy
             quizTypes = intent.getIntArrayExtra(Extras.EXTRA_QUIZ_TYPES) ?: intArrayOf()
 
-            quizFragment = QuizFragment().withArguments(
-                Extras.EXTRA_QUIZ_IDS to quizIds,
-                Extras.EXTRA_QUIZ_STRATEGY to quizStrategy,
-                Extras.EXTRA_QUIZ_TYPES to quizTypes)
+            val bundle = Bundle()
+            bundle.putLongArray(Extras.EXTRA_QUIZ_IDS, quizIds)
+            bundle.putSerializable(Extras.EXTRA_QUIZ_STRATEGY, quizStrategy)
+            bundle.putIntArray(Extras.EXTRA_QUIZ_TYPES, quizTypes)
+
+            quizFragment = QuizFragment()
+            quizFragment.arguments = bundle
         }
         addOrReplaceFragment(R.id.container_content, quizFragment)
 
@@ -96,10 +99,10 @@ class QuizActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> {
-                alert {
+                alertDialog {
                     title = getString(R.string.quit_quiz)
-                    yesButton { finish() }
-                    noButton { }
+                    okButton { finish() }
+                    cancelButton()
                 }.show()
                 return true
             }
@@ -108,10 +111,10 @@ class QuizActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        alert(R.string.quit_quiz) {
-            yesButton { finish() }
-            noButton { }
-            onKeyPressed { _, keyCode, _ ->
+        alertDialog(getString(R.string.quit_quiz)) {
+            okButton { finish() }
+            cancelButton()
+            setOnKeyListener { _, keyCode, _ ->
                 if (keyCode == KeyEvent.KEYCODE_BACK)
                     finish()
                 true

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
@@ -30,6 +30,7 @@ class QuizActivity : AppCompatActivity() {
     companion object : KLogging()
 
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val quizPresenter: QuizContract.Presenter by injector.instance()
     private lateinit var quizFragment: QuizFragment
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -40,7 +40,7 @@ import com.jehutyno.yomikata.util.*
 import com.jehutyno.yomikata.view.SwipeDirection
 import org.jetbrains.anko.support.v4.withArguments
 
-// Splitties
+// TODO: use splitties to write alertdialogs
 //import splitties.alertdialog.appcompat.alertDialog
 //import splitties.alertdialog.appcompat.cancelButton
 //import splitties.alertdialog.appcompat.messageResource
@@ -799,11 +799,11 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
     override fun onItemClick(position: Int) {
         Intent().putExtra(Extras.EXTRA_QUIZ_TYPE, adapter!!.words[position].second as Parcelable)
         val dialog = WordDetailDialogFragment()
-
-        val dialog1 = WordDetailDialogFragment().withArguments(
-            Extras.EXTRA_WORD_ID to adapter!!.words[position].first.id,
-            Extras.EXTRA_QUIZ_TYPE to if (presenter.hasMistaken()) null else adapter!!.words[position].second,
-            Extras.EXTRA_SEARCH_STRING to "")
+        val bundle = Bundle()
+        bundle.putLong(Extras.EXTRA_WORD_ID, adapter!!.words[position].first.id)
+        bundle.putSerializable(Extras.EXTRA_QUIZ_TYPE, if (presenter.hasMistaken()) null else adapter!!.words[position].second)
+        bundle.putString(Extras.EXTRA_SEARCH_STRING, "")
+        dialog.arguments = bundle
         dialog.show(childFragmentManager, "")
         dialog.isCancelable = true
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -660,6 +660,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
             message = getString(R.string.alert_session_finished, sessionLength)
             neutralButton(R.string.alert_continue) { presenter.onLaunchNextProgressiveSession() }
             positiveButton(R.string.alert_quit) { finishQuiz() }
+            setCancelable(false)    // avoid accidental click out of session
         }.show()
     }
 
@@ -681,9 +682,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
             neutralButton(R.string.alert_quit) {
                 finishQuiz()
             }
-            setOnCancelListener {
-                presenter.onFinishQuiz()
-            }
+            setCancelable(false)    // avoid accidental click out of session
         }.show()
     }
 
@@ -704,9 +703,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
             neutralButton(R.string.alert_quit) {
                 presenter.onFinishQuiz()
             }
-            setOnCancelListener {
-                presenter.onContinueAfterNonProgressiveSessionEnd()
-            }
+            setCancelable(false)    // avoid accidental click out of session
         }.show()
     }
 
@@ -724,6 +721,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
             positiveButton(R.string.alert_quit) {
                 finishQuiz()
             }
+            setCancelable(false)    // avoid accidental click out of session
         }.show()
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -3,7 +3,6 @@ package com.jehutyno.yomikata.screens.quiz
 import android.animation.Animator
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
@@ -860,9 +859,6 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
     }
 
     private fun addSelection(wordId: Long) {
-        val builder = AlertDialog.Builder(context)
-        builder.setTitle(R.string.new_selection)
-
         val input = EditText(activity)
         input.setSingleLine()
         input.hint = getString(R.string.selection_name)
@@ -872,17 +868,18 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
         params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
         params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
         input.layoutParams = params
-
         container.addView(input)
-        builder.setView(container)
-        builder.setPositiveButton(R.string.ok) { _, _ ->
-            val selectionId = presenter.createSelection(input.text.toString())
-            presenter.addWordToSelection(wordId, selectionId)
-            presenter.loadSelections()
-        }
-        builder.setNegativeButton(R.string.cancel_caps) {_, _ -> }
 
-        builder.show()
+        requireContext().alertDialog {
+            titleResource = R.string.new_selection
+            setView(container)
+            okButton {
+                val selectionId = presenter.createSelection(input.text.toString())
+                presenter.addWordToSelection(wordId, selectionId)
+                presenter.loadSelections()
+            }
+            cancelButton()
+        }.show()
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -438,7 +438,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
         requireContext().alertDialog {
             messageResource = R.string.quiz_empty
             okButton { requireActivity().finish() }
-            cancelButton { requireActivity().finish() }
+            setOnCancelListener { requireActivity().finish() }
         }.show()
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -47,6 +47,7 @@ import splitties.alertdialog.appcompat.*
 class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callback, TextToSpeech.OnInitListener {
 
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val voicesManager: VoicesManager by injector.instance()
     private lateinit var presenter: QuizContract.Presenter
     private var adapter: QuizItemPagerAdapter? = null

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizItemPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizItemPagerAdapter.kt
@@ -1,7 +1,7 @@
 package com.jehutyno.yomikata.screens.quiz
 
 import android.content.Context
-import android.preference.PreferenceManager
+import androidx.preference.PreferenceManager
 import androidx.core.content.ContextCompat
 import androidx.viewpager.widget.PagerAdapter
 import androidx.appcompat.widget.PopupMenu
@@ -18,8 +18,6 @@ import com.jehutyno.yomikata.model.Sentence
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.model.getWordColor
 import com.jehutyno.yomikata.util.*
-import org.jetbrains.anko.defaultSharedPreferences
-import org.jetbrains.anko.textColor
 import java.util.*
 
 /**
@@ -54,8 +52,10 @@ class QuizItemPagerAdapter(var context: Context, var callback: Callback) : Pager
         val session_count = view.findViewById<TextView>(R.id.session_count)
 
         session_count.text = "${position + 1} / ${words.size}"
-        btn_furi.isSelected = context.defaultSharedPreferences.getBoolean(Prefs.FURI_DISPLAYED.pref, true)
-        btn_trad.isSelected = context.defaultSharedPreferences.getBoolean(Prefs.TRAD_DISPLAYED.pref, true)
+
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        btn_furi.isSelected = pref.getBoolean(Prefs.FURI_DISPLAYED.pref, true)
+        btn_trad.isSelected = pref.getBoolean(Prefs.TRAD_DISPLAYED.pref, true)
 
         when (words[position].second) {
             QuizType.TYPE_PRONUNCIATION, QuizType.TYPE_PRONUNCIATION_QCM, QuizType.TYPE_JAP_EN -> {
@@ -63,7 +63,7 @@ class QuizItemPagerAdapter(var context: Context, var callback: Callback) : Pager
                 btn_trad.visibility = View.VISIBLE
                 trad_sentence.visibility = View.VISIBLE
                 trad_sentence.textSize = 16f
-                trad_sentence.textColor = ContextCompat.getColor(context, R.color.lighter_gray)
+                trad_sentence.setTextColor(ContextCompat.getColor(context, R.color.lighter_gray))
                 val sentenceNoFuri = sentenceNoFuri(sentence)
                 val colorEntireWord = word.isKana == 2 && words[position].second == QuizType.TYPE_JAP_EN
                 val wordTruePosition = if (colorEntireWord) 0 else getWordPositionInFuriSentence(sentence.jap, word)
@@ -91,7 +91,7 @@ class QuizItemPagerAdapter(var context: Context, var callback: Callback) : Pager
                 btn_trad.visibility = View.GONE
                 trad_sentence.visibility = View.VISIBLE
                 trad_sentence.movementMethod = ScrollingMovementMethod()
-                trad_sentence.textColor = getWordColor(context, word.level, word.points)
+                trad_sentence.setTextColor(getWordColor(context, word.level, word.points))
                 trad_sentence.textSize = PreferenceManager.getDefaultSharedPreferences(context).getString("font_size", "18")!!.toFloat()
                 trad_sentence.text = word.getTrad()
             }
@@ -119,14 +119,14 @@ class QuizItemPagerAdapter(var context: Context, var callback: Callback) : Pager
 
         btn_furi.setOnClickListener {
             btn_furi.isSelected = !btn_furi.isSelected
-            context.defaultSharedPreferences.edit().putBoolean(Prefs.FURI_DISPLAYED.pref, btn_furi.isSelected).apply()
+            pref.edit().putBoolean(Prefs.FURI_DISPLAYED.pref, btn_furi.isSelected).apply()
             notifyDataSetChanged()
             callback.onFuriClick(position, btn_furi.isSelected)
         }
 
         btn_trad.setOnClickListener {
             btn_trad.isSelected = !btn_trad.isSelected
-            context.defaultSharedPreferences.edit().putBoolean(Prefs.TRAD_DISPLAYED.pref, btn_trad.isSelected).apply()
+            pref.edit().putBoolean(Prefs.TRAD_DISPLAYED.pref, btn_trad.isSelected).apply()
             notifyDataSetChanged()
             callback.onTradClick(position)
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.util.Log
 import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.model.*
 import com.jehutyno.yomikata.repository.QuizRepository
@@ -13,7 +14,6 @@ import com.jehutyno.yomikata.repository.SentenceRepository
 import com.jehutyno.yomikata.repository.StatsRepository
 import com.jehutyno.yomikata.repository.WordRepository
 import com.jehutyno.yomikata.util.*
-import org.jetbrains.anko.defaultSharedPreferences
 import java.util.*
 
 /**
@@ -25,7 +25,7 @@ class QuizPresenter(
     private val statsRepository: StatsRepository, private val quizView: QuizContract.View,
     private var quizIds: LongArray, private var strategy: QuizStrategy, private val quizTypes: IntArray) : QuizContract.Presenter {
 
-    private val defaultSharedPreferences: SharedPreferences = context.defaultSharedPreferences
+    private val defaultSharedPreferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     private var quizWords = listOf<Pair<Word, QuizType>>()
     private var errors = arrayListOf<Pair<Word, QuizType>>()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -46,10 +46,7 @@ import com.jehutyno.yomikata.util.Extras.REQUEST_PREFS
 import com.jehutyno.yomikata.view.AppBarStateChangeListener
 import com.wooplr.spotlight.utils.SpotlightListener
 import mu.KLogging
-import splitties.alertdialog.appcompat.alertDialog
-import splitties.alertdialog.appcompat.cancelButton
-import splitties.alertdialog.appcompat.message
-import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.*
 import java.util.*
 
 
@@ -104,9 +101,9 @@ class QuizzesActivity : AppCompatActivity() {
                     progressDialog!!.dismiss()
                     progressDialog = null
                     alertDialog {
-                        title = getString(R.string.update_success_title)
+                        titleResource = R.string.update_success_title
                         okButton { }
-                        message = getString(R.string.update_success_message)
+                        messageResource = R.string.update_success_message
                         binding.pagerQuizzes.adapter = null
                         binding.pagerQuizzes.adapter = quizzesAdapter
                         selectedCategory = Categories.HOME
@@ -487,7 +484,7 @@ class QuizzesActivity : AppCompatActivity() {
             binding.multipleActions.collapse()
         else
             alertDialog {
-                title = getString(R.string.app_quit)
+                titleResource = R.string.app_quit
                 okButton { finishAffinity() }
                 cancelButton()
                 setOnKeyListener { _, keyCode, _ ->

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -31,6 +31,7 @@ import android.view.View.VISIBLE
 import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.preference.PreferenceManager
 import com.flaviofaria.kenburnsview.KenBurnsView
 import com.getbase.floatingactionbutton.FloatingActionButton
 import com.getbase.floatingactionbutton.FloatingActionsMenu
@@ -45,7 +46,10 @@ import com.jehutyno.yomikata.util.Extras.REQUEST_PREFS
 import com.jehutyno.yomikata.view.AppBarStateChangeListener
 import com.wooplr.spotlight.utils.SpotlightListener
 import mu.KLogging
-import org.jetbrains.anko.*
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.cancelButton
+import splitties.alertdialog.appcompat.message
+import splitties.alertdialog.appcompat.okButton
 import java.util.*
 
 
@@ -99,7 +103,7 @@ class QuizzesActivity : AppCompatActivity() {
                 if (intent.getBooleanExtra(UPDATE_FINISHED, false)) {
                     progressDialog!!.dismiss()
                     progressDialog = null
-                    alert {
+                    alertDialog {
                         title = getString(R.string.update_success_title)
                         okButton { }
                         message = getString(R.string.update_success_message)
@@ -128,7 +132,8 @@ class QuizzesActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AppCompatDelegate.setDefaultNightMode(defaultSharedPreferences.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        AppCompatDelegate.setDefaultNightMode(pref.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
 
         binding = ActivityQuizzesBinding.inflate(layoutInflater)
         val view = binding.root
@@ -204,7 +209,7 @@ class QuizzesActivity : AppCompatActivity() {
                         (quizzesAdapter.registered[binding.pagerQuizzes.currentItem] as QuizzesFragment).tutos()
                 }
 
-                defaultSharedPreferences.edit().putInt(Prefs.SELECTED_CATEGORY.pref, selectedCategory).apply()
+                pref.edit().putInt(Prefs.SELECTED_CATEGORY.pref, selectedCategory).apply()
                 displayCategoryTitle(selectedCategory)
                 binding.navView.setCheckedItem(quizzesAdapter.getMenuItemFromPosition(position))
             }
@@ -279,11 +284,11 @@ class QuizzesActivity : AppCompatActivity() {
     }
 
     private fun setupDrawerContent(navigationView: NavigationView) {
-        navigationView.getHeaderView(0).find<TextView>(R.id.version).text = getString(R.string.yomiakataz_drawer, packageManager.getPackageInfo(packageName, 0).versionName)
-        navigationView.getHeaderView(0).find<ImageView>(R.id.facebook).setOnClickListener { contactFacebook(this) }
-        navigationView.getHeaderView(0).find<ImageView>(R.id.discord).setOnClickListener { contactDiscord(this) }
-        navigationView.getHeaderView(0).find<ImageView>(R.id.play_store).setOnClickListener { contactPlayStore(this) }
-        navigationView.getHeaderView(0).find<ImageView>(R.id.share).setOnClickListener { shareApp(this) }
+        navigationView.getHeaderView(0).findViewById<TextView>(R.id.version).text = getString(R.string.yomiakataz_drawer, packageManager.getPackageInfo(packageName, 0).versionName)
+        navigationView.getHeaderView(0).findViewById<ImageView>(R.id.facebook).setOnClickListener { contactFacebook(this) }
+        navigationView.getHeaderView(0).findViewById<ImageView>(R.id.discord).setOnClickListener { contactDiscord(this) }
+        navigationView.getHeaderView(0).findViewById<ImageView>(R.id.play_store).setOnClickListener { contactPlayStore(this) }
+        navigationView.getHeaderView(0).findViewById<ImageView>(R.id.share).setOnClickListener { shareApp(this) }
 
         navigationView.setNavigationItemSelectedListener { menuItem ->
             binding.multipleActions.collapse()
@@ -334,11 +339,12 @@ class QuizzesActivity : AppCompatActivity() {
                 }
                 R.id.day_night_item -> {
                     menuItem.isChecked = !menuItem.isChecked
-                    menuItem.actionView?.find<SwitchCompat>(R.id.my_switch)?.toggle()
+                    menuItem.actionView?.findViewById<SwitchCompat>(R.id.my_switch)?.toggle()
                 }
                 R.id.settings -> {
                     menuItem.isChecked = false
-                    startActivityForResult(intentFor<PrefsActivity>(), REQUEST_PREFS)
+                    val intent = Intent(this, PrefsActivity::class.java)
+                    startActivityForResult(intent, REQUEST_PREFS)
                 }
                 else -> {
                 }
@@ -347,17 +353,18 @@ class QuizzesActivity : AppCompatActivity() {
             true
         }
 
-        navigationView.menu.findItem(R.id.day_night_item).actionView?.find<SwitchCompat>(R.id.my_switch)?.isChecked = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES
+        navigationView.menu.findItem(R.id.day_night_item).actionView?.findViewById<SwitchCompat>(R.id.my_switch)?.isChecked = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES
         navigationView.menu.findItem(R.id.day_night_item).isChecked = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES
-        navigationView.menu.findItem(R.id.day_night_item).actionView?.find<SwitchCompat>(R.id.my_switch)?.setOnCheckedChangeListener {
+        navigationView.menu.findItem(R.id.day_night_item).actionView?.findViewById<SwitchCompat>(R.id.my_switch)?.setOnCheckedChangeListener {
             switch, isChecked ->
             navigationView.menu.findItem(R.id.day_night_item).isChecked = isChecked
+            val pref = PreferenceManager.getDefaultSharedPreferences(this)
             if (isChecked) {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-                defaultSharedPreferences.edit().putInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES).apply()
+                pref.edit().putInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES).apply()
             } else {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-                defaultSharedPreferences.edit().putInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_NO).apply()
+                pref.edit().putInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_NO).apply()
             }
             binding.drawerLayout.closeDrawers()
             recreate = true
@@ -467,7 +474,10 @@ class QuizzesActivity : AppCompatActivity() {
                 binding.drawerLayout.openDrawer(GravityCompat.START)
                 return true
             }
-            R.id.search -> startActivity(intentFor<SearchResultActivity>())
+            R.id.search -> {
+                val intent = Intent(this, SearchResultActivity::class.java)
+                startActivity(intent)
+            }
         }
         return super.onOptionsItemSelected(item)
     }
@@ -476,11 +486,11 @@ class QuizzesActivity : AppCompatActivity() {
         if (binding.multipleActions.isExpanded)
             binding.multipleActions.collapse()
         else
-            alert {
+            alertDialog {
                 title = getString(R.string.app_quit)
-                yesButton { finishAffinity() }
-                noButton { }
-                onKeyPressed { _, keyCode, _ ->
+                okButton { finishAffinity() }
+                cancelButton()
+                setOnKeyListener { _, keyCode, _ ->
                     if (keyCode == KeyEvent.KEYCODE_BACK)
                         finishAffinity()
                     true

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -301,7 +301,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             return
         }
         requireContext().alertDialog {
-            title = getString(R.string.selection_edit)
+            titleResource = R.string.selection_edit
             val input = EditText(activity)
             input.setSingleLine()
             input.hint = getString(R.string.selection_name)
@@ -325,7 +325,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
 
             neutralButton(R.string.action_delete) {
                 requireContext().alertDialog {
-                    title = getString(R.string.selection_delete_sure)
+                    titleResource = R.string.selection_delete_sure
                     okButton {
                         mpresenter!!.deleteQuiz(adapter.items[position].id)
                         adapter.deleteItem(position)
@@ -347,7 +347,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
 
     override fun addSelection() {
         requireContext().alertDialog {
-            title = getString(R.string.new_selection)
+            titleResource = R.string.new_selection
             val input = EditText(activity)
             input.setSingleLine()
             input.inputType = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -304,27 +304,29 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             // TODO propose to add all words to selections
             return
         }
+        val input = EditText(activity)
+        input.setSingleLine()
+        input.hint = getString(R.string.selection_name)
+        input.setText(adapter.items[position].getName())
+
+        val container = FrameLayout(requireActivity())
+        val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        input.layoutParams = params
+
+        input.addTextChangedListener(object : TextValidator(input) {
+            override fun validate(textView: TextView, text: String) {
+                if (text.isEmpty())
+                    input.error = getString(R.string.selection_not_empty_name)
+                else
+                    input.error = null
+            }
+        })
+        container.addView(input)
+
         requireContext().alertDialog {
             titleResource = R.string.selection_edit
-            val input = EditText(activity)
-            input.setSingleLine()
-            input.hint = getString(R.string.selection_name)
-            input.setText(adapter.items[position].getName())
-            val container = FrameLayout(requireActivity())
-            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            input.layoutParams = params
-            input.addTextChangedListener(object : TextValidator(input) {
-                override fun validate(textView: TextView, text: String) {
-                    if (text.isEmpty())
-                        input.error = getString(R.string.selection_not_empty_name)
-                    else
-                        input.error = null
-                }
-            })
-
-            container.addView(input)
             setView(container)
 
             neutralButton(R.string.action_delete) {
@@ -350,29 +352,33 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     }
 
     override fun addSelection() {
+        val input = EditText(activity)
+        input.setSingleLine()
+        input.inputType = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+        input.hint = getString(R.string.selection_name)
+
+        val container = FrameLayout(requireActivity())
+        val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+        input.layoutParams = params
+
+        input.addTextChangedListener(object : TextValidator(input) {
+            override fun validate(textView: TextView, text: String) {
+                if (text.isEmpty()) {
+                    input.error = getString(R.string.selection_not_empty_name)
+                } else {
+                    input.error = null
+                }
+            }
+        })
+        input.error = getString(R.string.selection_not_empty_name)
+        container.addView(input)
+
         requireContext().alertDialog {
             titleResource = R.string.new_selection
-            val input = EditText(activity)
-            input.setSingleLine()
-            input.inputType = InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
-            input.hint = getString(R.string.selection_name)
-            val container = FrameLayout(requireActivity())
-            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-            input.layoutParams = params
-            input.addTextChangedListener(object : TextValidator(input) {
-                override fun validate(textView: TextView, text: String) {
-                    if (text.isEmpty()) {
-                        input.error = getString(R.string.selection_not_empty_name)
-                    } else {
-                        input.error = null
-                    }
-                }
-            })
-            input.error = getString(R.string.selection_not_empty_name)
-            container.addView(input)
             setView(container)
+
             okButton {
                 if (input.error == null) {
                     mpresenter!!.createQuiz(input.text.toString())

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -24,7 +24,8 @@ import com.jehutyno.yomikata.screens.content.ContentActivity
 import com.jehutyno.yomikata.screens.quiz.QuizActivity
 import com.jehutyno.yomikata.util.*
 import com.wooplr.spotlight.utils.SpotlightListener
-import org.jetbrains.anko.*
+import org.jetbrains.anko.doAsync
+import org.jetbrains.anko.support.v4.uiThread
 import splitties.alertdialog.appcompat.*
 import java.lang.Thread.sleep
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -13,6 +13,8 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.TextView
+import android.widget.Toast
+import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.android.appKodein
 import com.github.salomonbrys.kodein.instance
 import com.jehutyno.yomikata.R
@@ -23,9 +25,7 @@ import com.jehutyno.yomikata.screens.quiz.QuizActivity
 import com.jehutyno.yomikata.util.*
 import com.wooplr.spotlight.utils.SpotlightListener
 import org.jetbrains.anko.*
-import org.jetbrains.anko.support.v4.alert
-import org.jetbrains.anko.support.v4.defaultSharedPreferences
-import org.jetbrains.anko.support.v4.toast
+import splitties.alertdialog.appcompat.*
 import java.lang.Thread.sleep
 
 
@@ -57,8 +57,8 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        selectedCategory = arguments!!.getInt(Extras.EXTRA_CATEGORY)
-        adapter = QuizzesAdapter(activity!!, selectedCategory, this, selectedCategory == Categories.CATEGORY_SELECTIONS)
+        selectedCategory = requireArguments().getInt(Extras.EXTRA_CATEGORY)
+        adapter = QuizzesAdapter(requireActivity(), selectedCategory, this, selectedCategory == Categories.CATEGORY_SELECTIONS)
     }
 
     override fun onResume() {
@@ -83,36 +83,36 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         }
 
         if (mpresenter == null)
-            mpresenter = QuizzesPresenter(activity!!.appKodein.invoke().instance(), context!!.appKodein.invoke().instance(), context!!.appKodein.invoke().instance(), this)
+            mpresenter = QuizzesPresenter(requireActivity().appKodein.invoke().instance(), requireContext().appKodein.invoke().instance(), requireContext().appKodein.invoke().instance(), this)
         mpresenter!!.initQuizTypes()
 
         binding.btnPronunciationQcmSwitch.setOnClickListener {
             mpresenter!!.pronunciationQcmSwitch()
-            spotlightTuto(activity!!, binding.btnPronunciationQcmSwitch, getString(R.string.tutos_pronunciation_mcq), getString(R.string.tutos_pronunciation_mcq_message), SpotlightListener { })
+            spotlightTuto(requireActivity(), binding.btnPronunciationQcmSwitch, getString(R.string.tutos_pronunciation_mcq), getString(R.string.tutos_pronunciation_mcq_message), SpotlightListener { })
         }
         binding.btnPronunciationSwitch.setOnClickListener {
             mpresenter!!.pronunciationSwitch()
-            spotlightTuto(activity!!, binding.btnPronunciationSwitch, getString(R.string.tutos_pronunciation_quiz), getString(R.string.tutos_pronunciation_quiz_message), SpotlightListener { })
+            spotlightTuto(requireActivity(), binding.btnPronunciationSwitch, getString(R.string.tutos_pronunciation_quiz), getString(R.string.tutos_pronunciation_quiz_message), SpotlightListener { })
         }
         binding.btnAudioSwitch.setOnClickListener {
-            spotlightTuto(activity!!, binding.btnAudioSwitch, getString(R.string.tutos_audio_quiz), getString(R.string.tutos_audio_quiz_message), SpotlightListener { })
-            val speechAvailability = checkSpeechAvailability(activity!!, ttsSupported, getCategoryLevel(selectedCategory))
+            spotlightTuto(requireActivity(), binding.btnAudioSwitch, getString(R.string.tutos_audio_quiz), getString(R.string.tutos_audio_quiz_message), SpotlightListener { })
+            val speechAvailability = checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(selectedCategory))
             when (speechAvailability) {
-                SpeechAvailability.NOT_AVAILABLE -> speechNotSupportedAlert(activity!!, getCategoryLevel(selectedCategory), { (activity as QuizzesActivity).quizzesAdapter.notifyDataSetChanged() })
+                SpeechAvailability.NOT_AVAILABLE -> speechNotSupportedAlert(requireActivity(), getCategoryLevel(selectedCategory), { (activity as QuizzesActivity).quizzesAdapter.notifyDataSetChanged() })
                 else -> mpresenter!!.audioSwitch()
             }
         }
         binding.btnEnJapSwitch.setOnClickListener {
             mpresenter!!.enJapSwitch()
-            spotlightTuto(activity!!, binding.btnEnJapSwitch, getString(R.string.tutos_en_jp), getString(R.string.tutos_en_jp_message), SpotlightListener { })
+            spotlightTuto(requireActivity(), binding.btnEnJapSwitch, getString(R.string.tutos_en_jp), getString(R.string.tutos_en_jp_message), SpotlightListener { })
         }
         binding.btnJapEnSwitch.setOnClickListener {
             mpresenter!!.japEnSwitch()
-            spotlightTuto(activity!!, binding.btnJapEnSwitch, getString(R.string.tutos_jp_en), getString(R.string.tutos_jp_en_message), SpotlightListener { })
+            spotlightTuto(requireActivity(), binding.btnJapEnSwitch, getString(R.string.tutos_jp_en), getString(R.string.tutos_jp_en_message), SpotlightListener { })
         }
         binding.btnAutoSwitch.setOnClickListener {
             mpresenter!!.autoSwitch()
-            spotlightTuto(activity!!, binding.btnAutoSwitch, getString(R.string.tutos_auto_quiz), getString(R.string.tutos_auto_quiz_message), SpotlightListener { })
+            spotlightTuto(requireActivity(), binding.btnAutoSwitch, getString(R.string.tutos_auto_quiz), getString(R.string.tutos_auto_quiz_message), SpotlightListener { })
         }
 
         binding.playLow.setOnClickListener {
@@ -128,8 +128,9 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             openContent(selectedCategory, 3)
         }
 
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
         if (selectedCategory == -1 || selectedCategory == 8
-            || defaultSharedPreferences.getBoolean(Prefs.VOICE_DOWNLOADED_LEVEL_V.pref +
+            || pref.getBoolean(Prefs.VOICE_DOWNLOADED_LEVEL_V.pref +
             "${getLevelDownloadVersion(getCategoryLevel(selectedCategory))}_${getCategoryLevel(selectedCategory)}", false)) {
             binding.download.visibility = GONE
         } else {
@@ -142,7 +143,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         }
 
         binding.download.setOnClickListener {
-            alert {
+            requireContext().alertDialog {
                 if (getLevelDownloadVersion(getCategoryLevel(selectedCategory)) > 0 && previousVoicesDownloaded(getLevelDownloadVersion(getCategoryLevel(selectedCategory)))) {
                     titleResource = R.string.update_voices_alert
                     message = getString(R.string.update_voices_alert_message, getLevelDownloadSize(getCategoryLevel(selectedCategory)))
@@ -157,8 +158,9 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     }
 
     fun previousVoicesDownloaded(downloadVersion: Int): Boolean {
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
         return (0 until downloadVersion).any {
-            defaultSharedPreferences.getBoolean("${Prefs.VOICE_DOWNLOADED_LEVEL_V.pref}${it}_${getCategoryLevel(selectedCategory)}", false)
+            pref.getBoolean("${Prefs.VOICE_DOWNLOADED_LEVEL_V.pref}${it}_${getCategoryLevel(selectedCategory)}", false)
         }
     }
 
@@ -204,7 +206,8 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
 
         // No quiz to launch
         if (ids.size == 0 || mpresenter!!.countQuiz(ids.toLongArray()) <= 0) {
-            toast(getString(R.string.error_no_quiz_no_word))
+            val toast = Toast.makeText(context, R.string.error_no_quiz_no_word, Toast.LENGTH_SHORT)
+            toast.show()
             return
         }
 
@@ -293,57 +296,57 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     }
 
     override fun onItemLongClick(position: Int) {
-        if (selectedCategory == Categories.CATEGORY_SELECTIONS) {
-            alert {
-                title = getString(R.string.selection_edit)
-                val input = EditText(activity)
-                input.setSingleLine()
-                input.hint = getString(R.string.selection_name)
-                input.setText(adapter.items[position].getName())
-                val container = FrameLayout(requireActivity())
-                val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-                params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-                params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-                input.layoutParams = params
-                input.addTextChangedListener(object : TextValidator(input) {
-                    override fun validate(textView: TextView, text: String) {
-                        if (text.isEmpty())
-                            input.error = getString(R.string.selection_not_empty_name)
-                        else
-                            input.error = null
-                    }
-                })
-
-                container.addView(input)
-                customView = container
-
-                neutralPressed(R.string.action_delete) {
-                    alert {
-                        title = getString(R.string.selection_delete_sure)
-                        okButton {
-                            mpresenter!!.deleteQuiz(adapter.items[position].id)
-                            adapter.deleteItem(position)
-                        }
-                        cancelButton { }
-                    }.show()
-                }
-                okButton {
-                    if (adapter.items[position].getName() != input.text.toString() && input.error == null) {
-                        mpresenter!!.updateQuizName(adapter.items[position].id, input.text.toString())
-                        adapter.items[position].nameFr = input.text.toString()
-                        adapter.items[position].nameEn = input.text.toString()
-                        adapter.notifyItemChanged(position)
-                    }
-                }
-                cancelButton { }
-            }.show()
-        } else {
+        if (selectedCategory != Categories.CATEGORY_SELECTIONS) {
             // TODO propose to add all words to selections
+            return
         }
+        requireContext().alertDialog {
+            title = getString(R.string.selection_edit)
+            val input = EditText(activity)
+            input.setSingleLine()
+            input.hint = getString(R.string.selection_name)
+            input.setText(adapter.items[position].getName())
+            val container = FrameLayout(requireActivity())
+            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+            input.layoutParams = params
+            input.addTextChangedListener(object : TextValidator(input) {
+                override fun validate(textView: TextView, text: String) {
+                    if (text.isEmpty())
+                        input.error = getString(R.string.selection_not_empty_name)
+                    else
+                        input.error = null
+                }
+            })
+
+            container.addView(input)
+            setView(container)
+
+            neutralButton(R.string.action_delete) {
+                requireContext().alertDialog {
+                    title = getString(R.string.selection_delete_sure)
+                    okButton {
+                        mpresenter!!.deleteQuiz(adapter.items[position].id)
+                        adapter.deleteItem(position)
+                    }
+                    cancelButton { }
+                }.show()
+            }
+            okButton {
+                if (adapter.items[position].getName() != input.text.toString() && input.error == null) {
+                    mpresenter!!.updateQuizName(adapter.items[position].id, input.text.toString())
+                    adapter.items[position].nameFr = input.text.toString()
+                    adapter.items[position].nameEn = input.text.toString()
+                    adapter.notifyItemChanged(position)
+                }
+            }
+            cancelButton { }
+        }.show()
     }
 
     override fun addSelection() {
-        alert {
+        requireContext().alertDialog {
             title = getString(R.string.new_selection)
             val input = EditText(activity)
             input.setSingleLine()
@@ -365,7 +368,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             })
             input.error = getString(R.string.selection_not_empty_name)
             container.addView(input)
-            customView = container
+            setView(container)
             okButton {
                 if (input.error == null) {
                     mpresenter!!.createQuiz(input.text.toString())
@@ -392,13 +395,13 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             sleep(500)
             uiThread {
                 if (activity != null) {
-                    spotlightTuto(activity!!, binding.btnPronunciationQcmSwitch, getString(R.string.tuto_quiz_type), getString(R.string.tuto_quiz_type_message),
+                    spotlightTuto(requireActivity(), binding.btnPronunciationQcmSwitch, getString(R.string.tuto_quiz_type), getString(R.string.tuto_quiz_type_message),
                         SpotlightListener {
                             if (activity != null) {
-                                spotlightTuto(activity!!, binding.textLow, getString(R.string.tuto_progress), getString(R.string.tuto_progress_message),
+                                spotlightTuto(requireActivity(), binding.textLow, getString(R.string.tuto_progress), getString(R.string.tuto_progress_message),
                                     SpotlightListener {
                                         if (activity != null) {
-                                            spotlightTuto(activity!!, binding.recyclerview.findViewHolderForAdapterPosition(0)?.itemView?.find(R.id.quiz_check), getString(R.string.tuto_part_selection), getString(R.string.tuto_part_selection_message),
+                                            spotlightTuto(requireActivity(), binding.recyclerview.findViewHolderForAdapterPosition(0)?.itemView?.findViewById(R.id.quiz_check), getString(R.string.tuto_part_selection), getString(R.string.tuto_part_selection_message),
                                                 SpotlightListener {})
                                         }
                                     })

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -24,8 +24,11 @@ import com.jehutyno.yomikata.screens.content.ContentActivity
 import com.jehutyno.yomikata.screens.quiz.QuizActivity
 import com.jehutyno.yomikata.util.*
 import com.wooplr.spotlight.utils.SpotlightListener
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.support.v4.uiThread
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
 import splitties.alertdialog.appcompat.*
 import java.lang.Thread.sleep
 
@@ -392,9 +395,11 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     }
 
     fun tutos() {
-        doAsync {
-            sleep(500)
-            uiThread {
+        MainScope().async {
+            withContext(IO) {
+                sleep(500)
+            }
+            withContext(Main) {
                 if (activity != null) {
                     spotlightTuto(requireActivity(), binding.btnPronunciationQcmSwitch, getString(R.string.tuto_quiz_type), getString(R.string.tuto_quiz_type_message),
                         SpotlightListener {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
@@ -1,6 +1,7 @@
 package com.jehutyno.yomikata.screens.content
 
 import android.content.Context
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
@@ -12,7 +13,7 @@ import com.jehutyno.yomikata.screens.home.HomeFragment
 import com.jehutyno.yomikata.screens.quizzes.QuizzesFragment
 import com.jehutyno.yomikata.util.Categories
 import com.jehutyno.yomikata.util.Extras
-import org.jetbrains.anko.support.v4.withArguments
+
 
 /**
  * Created by valentin on 19/12/2016.
@@ -34,10 +35,12 @@ class QuizzesPagerAdapter(val context: Context, fm: FragmentManager) : FragmentS
 
     override fun getItem(position: Int): Fragment {
         if (position == 0) {
-            val homeFragment = HomeFragment()
-            return homeFragment
+            return HomeFragment()
         } else {
-            val quizzesFragment = QuizzesFragment().withArguments(Extras.EXTRA_CATEGORY to categories[position])
+            val bundle = Bundle()
+            bundle.putInt(Extras.EXTRA_CATEGORY, categories[position])
+            val quizzesFragment = QuizzesFragment()
+            quizzesFragment.arguments = bundle
             return quizzesFragment
         }
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPresenter.kt
@@ -2,6 +2,7 @@ package com.jehutyno.yomikata.screens.quizzes
 
 import android.content.Context
 import android.util.Log
+import androidx.preference.PreferenceManager
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.model.StatAction
 import com.jehutyno.yomikata.model.StatResult
@@ -12,7 +13,6 @@ import com.jehutyno.yomikata.util.Prefs
 import com.jehutyno.yomikata.util.QuizStrategy
 import com.jehutyno.yomikata.util.QuizType
 import mu.KLogging
-import org.jetbrains.anko.defaultSharedPreferences
 import java.util.*
 
 /**
@@ -171,7 +171,8 @@ class QuizzesPresenter(
     }
 
     private fun getIntArrayFromPrefs(key: String, default: Int): ArrayList<Int> {
-        val savedString = context.defaultSharedPreferences.getString(key, "")
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val savedString = pref.getString(key, "")
         val savedList = ArrayList<Int>(5)
         if (savedString == "" && default != -1) {
             savedList.add(default)
@@ -190,16 +191,18 @@ class QuizzesPresenter(
         list.forEach {
             str.append(it).append(",")
         }
-        context.defaultSharedPreferences.edit().putString(key, str.toString()).apply()
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        pref.edit().putString(key, str.toString()).apply()
     }
 
     override fun launchQuizClick(strategy: QuizStrategy, title: String, category: Int) {
         statsRepository.addStatEntry(StatAction.LAUNCH_QUIZ_FROM_CATEGORY, category.toLong(), Calendar.getInstance().timeInMillis, StatResult.OTHER)
-        val cat1 = context.defaultSharedPreferences.getInt(Prefs.LATEST_CATEGORY_1.pref, -1)
+        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val cat1 = pref.getInt(Prefs.LATEST_CATEGORY_1.pref, -1)
 
         if (category != cat1) {
-            context.defaultSharedPreferences.edit().putInt(Prefs.LATEST_CATEGORY_2.pref, cat1).apply()
-            context.defaultSharedPreferences.edit().putInt(Prefs.LATEST_CATEGORY_1.pref, category).apply()
+            pref.edit().putInt(Prefs.LATEST_CATEGORY_2.pref, cat1).apply()
+            pref.edit().putInt(Prefs.LATEST_CATEGORY_1.pref, category).apply()
         }
         quizzesView.launchQuiz(strategy, selectedTypes.toIntArray(), title)
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultActivity.kt
@@ -18,6 +18,7 @@ import org.jetbrains.anko.defaultSharedPreferences
 class SearchResultActivity : AppCompatActivity() {
 
     private val injector = KodeinInjector()
+    @Suppress("unused")
     private val searchResultPresenter: SearchResultContract.Presenter by injector.instance()
     private lateinit var searchResultFragment : SearchResultFragment
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import android.view.MenuItem
+import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
 import com.github.salomonbrys.kodein.android.appKodein
@@ -13,7 +14,7 @@ import com.github.salomonbrys.kodein.provider
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.util.Prefs
 import com.jehutyno.yomikata.util.addOrReplaceFragment
-import org.jetbrains.anko.defaultSharedPreferences
+
 
 class SearchResultActivity : AppCompatActivity() {
 
@@ -24,7 +25,8 @@ class SearchResultActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AppCompatDelegate.setDefaultNightMode(defaultSharedPreferences.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        AppCompatDelegate.setDefaultNightMode(pref.getInt(Prefs.DAY_NIGHT_MODE.pref, AppCompatDelegate.MODE_NIGHT_YES))
         setContentView(R.layout.activity_search)
 
         if(resources.getBoolean(R.bool.portrait_only)){

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
@@ -212,18 +212,21 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
         }
 
         private fun addSelection(selectedWords: ArrayList<Word>) {
+            val input = EditText(activity)
+            input.setSingleLine()
+            input.hint = getString(R.string.selection_name)
+
+            val container = FrameLayout(requireActivity())
+            val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
+            params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
+            input.layoutParams = params
+            container.addView(input)
+
             requireContext().alertDialog {
                 titleResource = R.string.new_selection
-                val input = EditText(activity)
-                input.setSingleLine()
-                input.hint = getString(R.string.selection_name)
-                val container = FrameLayout(requireActivity())
-                val params = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-                params.leftMargin = DimensionHelper.getPixelFromDip(activity, 20)
-                params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
-                input.layoutParams = params
-                container.addView(input)
                 setView(container)
+
                 okButton {
                     val selectionId = searchResultPresenter.createSelection(input.text.toString())
                     selectedWords.forEach {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
@@ -5,6 +5,7 @@ import android.view.*
 import android.view.MenuItem
 import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.Toast
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
@@ -18,12 +19,10 @@ import com.jehutyno.yomikata.screens.content.WordsAdapter
 import com.jehutyno.yomikata.screens.content.word.WordDetailDialogFragment
 import com.jehutyno.yomikata.util.DimensionHelper
 import com.jehutyno.yomikata.util.Extras
-import org.jetbrains.anko.cancelButton
-import org.jetbrains.anko.find
-import org.jetbrains.anko.okButton
-import org.jetbrains.anko.support.v4.alert
-import org.jetbrains.anko.support.v4.toast
-import org.jetbrains.anko.support.v4.withArguments
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.cancelButton
+import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.title
 import java.util.*
 
 /**
@@ -48,7 +47,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        adapter = WordsAdapter(activity!!, this)
+        adapter = WordsAdapter(requireActivity(), this)
         layoutManager = GridLayoutManager(context, 2)
 
         setHasOptionsMenu(true)
@@ -81,7 +80,8 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
 
     override fun displayNoResults() {
         adapter.clearData()
-        toast(getString(R.string.search_no_results))
+        val toast = Toast.makeText(context, R.string.search_no_results, Toast.LENGTH_SHORT)
+        toast.show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -125,17 +125,20 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
     }
 
     override fun onItemClick(position: Int) {
-        val dialog = WordDetailDialogFragment().withArguments(
-            Extras.EXTRA_QUIZ_IDS to longArrayOf(),
-            Extras.EXTRA_WORD_POSITION to position,
-            Extras.EXTRA_SEARCH_STRING to searchString)
+        val bundle = Bundle()
+        bundle.putLongArray(Extras.EXTRA_QUIZ_IDS, longArrayOf())
+        bundle.putInt(Extras.EXTRA_WORD_POSITION, position)
+        bundle.putString(Extras.EXTRA_SEARCH_STRING, searchString)
+
+        val dialog = WordDetailDialogFragment()
+        dialog.arguments = bundle
         dialog.show(childFragmentManager, "")
         dialog.isCancelable = true
 
     }
 
     override fun onCategoryIconClick(position: Int) {
-        activity!!.startActionMode(actionModeCallback)
+        requireActivity().startActionMode(actionModeCallback)
     }
 
     override fun onCheckChange(position: Int, check: Boolean) {
@@ -160,7 +163,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
                     adapter.notifyDataSetChanged()
                 }
                 1 -> {
-                    val popup = PopupMenu(activity!!, activity!!.find(1))
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(1))
                     popup.menuInflater.inflate(R.menu.popup_selections, popup.menu)
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
@@ -185,7 +188,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
 
                 }
                 2 -> {
-                    val popup = PopupMenu(activity!!, activity!!.find(2))
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(2))
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
                     }
@@ -212,7 +215,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
         }
 
         private fun addSelection(selectedWords: ArrayList<Word>) {
-            alert {
+            requireContext().alertDialog {
                 title = getString(R.string.new_selection)
                 val input = EditText(activity)
                 input.setSingleLine()
@@ -223,7 +226,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
                 params.rightMargin = DimensionHelper.getPixelFromDip(activity, 20)
                 input.layoutParams = params
                 container.addView(input)
-                customView = container
+                setView(container)
                 okButton {
                     val selectionId = searchResultPresenter.createSelection(input.text.toString())
                     selectedWords.forEach {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
@@ -19,10 +19,7 @@ import com.jehutyno.yomikata.screens.content.WordsAdapter
 import com.jehutyno.yomikata.screens.content.word.WordDetailDialogFragment
 import com.jehutyno.yomikata.util.DimensionHelper
 import com.jehutyno.yomikata.util.Extras
-import splitties.alertdialog.appcompat.alertDialog
-import splitties.alertdialog.appcompat.cancelButton
-import splitties.alertdialog.appcompat.okButton
-import splitties.alertdialog.appcompat.title
+import splitties.alertdialog.appcompat.*
 import java.util.*
 
 /**
@@ -216,7 +213,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
 
         private fun addSelection(selectedWords: ArrayList<Word>) {
             requireContext().alertDialog {
-                title = getString(R.string.new_selection)
+                titleResource = R.string.new_selection
                 val input = EditText(activity)
                 input.setSingleLine()
                 input.hint = getString(R.string.selection_name)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/splash/SplashActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/splash/SplashActivity.kt
@@ -6,13 +6,15 @@ import android.os.Handler
 import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import android.view.View
+import androidx.preference.PreferenceManager
 import com.jehutyno.yomikata.databinding.ActivitySplashBinding
 import com.jehutyno.yomikata.screens.quizzes.QuizzesActivity
 import com.jehutyno.yomikata.util.Prefs
 import com.jehutyno.yomikata.util.migrateFromYomikata
 import com.jehutyno.yomikata.util.updateBDD
-import org.jetbrains.anko.defaultSharedPreferences
 
+
+// TODO: migrate to splashScreen https://developer.android.com/develop/ui/views/launch/splash-screen/migrate
 class SplashActivity : AppCompatActivity() {
 
     // View Binding
@@ -26,10 +28,11 @@ class SplashActivity : AppCompatActivity() {
         val view = binding.root
         setContentView(view)
 
-        if (defaultSharedPreferences.getBoolean(Prefs.DB_UPDATE_ONGOING.pref, false))
-            defaultSharedPreferences.getString(Prefs.DB_UPDATE_FILE.pref, "")?.let {
+        val pref = PreferenceManager.getDefaultSharedPreferences(this)
+        if (pref.getBoolean(Prefs.DB_UPDATE_ONGOING.pref, false))
+            pref.getString(Prefs.DB_UPDATE_FILE.pref, "")?.let {
                 updateBDD(null, it,
-                    defaultSharedPreferences.getInt(Prefs.DB_UPDATE_OLD_VERSION.pref, -1))
+                    pref.getInt(Prefs.DB_UPDATE_OLD_VERSION.pref, -1))
             }
 
         binding.pathView.useNaturalColors()
@@ -44,9 +47,9 @@ class SplashActivity : AppCompatActivity() {
         val handler = Handler(Looper.getMainLooper())
         handler.postDelayed(
             {
-                if (!defaultSharedPreferences.getBoolean("migrationYomiDone", false)) {
+                if (!pref.getBoolean("migrationYomiDone", false)) {
                     migrateFromYomikata()
-                    defaultSharedPreferences.edit().putBoolean("migrationYomiDone", true).apply()
+                    pref.edit().putBoolean("migrationYomiDone", true).apply()
                 }
                 val intent = Intent(this@SplashActivity, QuizzesActivity::class.java)
                 startActivity(intent)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
@@ -58,7 +58,7 @@ fun Activity.migrateFromYomikata() {
     val context = this
     val toPath = getString(R.string.db_path)
     val toName = getString(R.string.db_name_yomi)
-    val file = File(toPath + "/" + toName)
+    val file = File("$toPath/$toName")
     if (file.exists()) {
         try {
             CopyUtils.reinitDataBase(this)
@@ -68,21 +68,20 @@ fun Activity.migrateFromYomikata() {
             // TODO: use coroutines library
             doAsync {
                 wordTables.forEach {
-                    val wordtable = migrationSource.getWordTable(it)
-                    wordtable.forEach {
+                    val wordTable = migrationSource.getWordTable(it)
+                    wordTable.forEach { word ->
                         val source = WordSource(context)
-                        if (it.counterTry > 0 || it.priority > 0)
-                            source.restoreWord(it.word, it.prononciation, it)
+                        if (word.counterTry > 0 || word.priority > 0)
+                            source.restoreWord(word.word, word.prononciation, word)
                     }
                 }
                 File(toPath + toName).delete()
-
             }
         } catch (exception: Exception) {
             val builder = AlertDialog.Builder(this)
             builder.setTitle(R.string.restore_error)
             builder.setMessage(R.string.restore_error_message)
-            builder.setPositiveButton(R.string.ok) {_, _, -> }
+            builder.setPositiveButton(R.string.ok) {_, _ -> }
             builder.show()
         }
     }
@@ -97,7 +96,7 @@ fun Context.updateBDD(db: SQLiteDatabase?, filePathEncrypted: String, oldVersion
         }, 2000)
     var filePath = ""
     File(getString(R.string.db_path) + UpdateSQLiteHelper.UPDATE_DATABASE_NAME).delete()
-    if (!filePathEncrypted.isEmpty()) {
+    if (filePathEncrypted.isNotEmpty()) {
         val file = File(filePathEncrypted)
         filePath = filePathEncrypted.replace(".yomikataz", ".import")
         try {
@@ -154,7 +153,7 @@ fun Context.updateBDD(db: SQLiteDatabase?, filePathEncrypted: String, oldVersion
                 sendBroadcast(intent)
             }
         }
-        if (!filePath.isEmpty()) {
+        if (filePath.isNotEmpty()) {
             statSource.removeAllStats()
             stats.forEach {
                 statSource.addStatEntry(it)
@@ -170,9 +169,9 @@ fun Context.updateBDD(db: SQLiteDatabase?, filePathEncrypted: String, oldVersion
             val quiz = quizSource.getQuiz(it.id)
             if (quiz == null) {
                 val id = quizSource.saveQuiz(it.getName(), it.category)
-                quizIdsMap.put(id, it.id)
+                quizIdsMap[id] = it.id
             } else {
-                quizIdsMap.put(quiz.id, it.id)
+                quizIdsMap[quiz.id] = it.id
             }
             i++
             if (i % 100 == 0) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
@@ -21,7 +21,8 @@ import com.jehutyno.yomikata.repository.migration.MigrationSource
 import com.jehutyno.yomikata.repository.migration.MigrationTable
 import com.jehutyno.yomikata.repository.migration.MigrationTables
 import com.jehutyno.yomikata.screens.quizzes.QuizzesActivity
-import org.jetbrains.anko.doAsync
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
 import java.io.File
 
 
@@ -65,8 +66,7 @@ fun Activity.migrateFromYomikata() {
             val migrationSource = MigrationSource(this, DatabaseHelper.getInstance(this, toName, toPath))
             val wordTables = MigrationTable.allTables(MigrationTables.values())
 
-            // TODO: use coroutines library
-            doAsync {
+            MainScope().async {
                 wordTables.forEach {
                     val wordTable = migrationSource.getWordTable(it)
                     wordTable.forEach { word ->
@@ -126,7 +126,7 @@ fun Context.updateBDD(db: SQLiteDatabase?, filePathEncrypted: String, oldVersion
     val kanjiSoloCount = kanjiSoloSource.kanjiSoloCount(db)
     val radCount = kanjiSoloSource.radicalsCount(db)
 
-    doAsync {
+    MainScope().async {
         var i = 0
         val intent = Intent()
         intent.action = QuizzesActivity.UPDATE_INTENT

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
@@ -1,7 +1,6 @@
 package com.jehutyno.yomikata.util
 
 import android.app.Activity
-import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.database.sqlite.SQLiteDatabase
@@ -23,6 +22,10 @@ import com.jehutyno.yomikata.repository.migration.MigrationTables
 import com.jehutyno.yomikata.screens.quizzes.QuizzesActivity
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.async
+import splitties.alertdialog.appcompat.alertDialog
+import splitties.alertdialog.appcompat.messageResource
+import splitties.alertdialog.appcompat.okButton
+import splitties.alertdialog.appcompat.titleResource
 import java.io.File
 
 
@@ -78,11 +81,11 @@ fun Activity.migrateFromYomikata() {
                 File(toPath + toName).delete()
             }
         } catch (exception: Exception) {
-            val builder = AlertDialog.Builder(this)
-            builder.setTitle(R.string.restore_error)
-            builder.setMessage(R.string.restore_error_message)
-            builder.setPositiveButton(R.string.ok) {_, _ -> }
-            builder.show()
+            alertDialog {
+                titleResource = R.string.restore_error
+                messageResource = R.string.restore_error_message
+                okButton()
+            }.show()
         }
     }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/Extras.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/Extras.kt
@@ -22,7 +22,7 @@ object Extras {
 
     @JvmStatic val REQUEST_PREFS = 33
     @JvmStatic val REQUEST_RESTORE = 55
-    @JvmStatic val REQUEST_EXTERNAL_STORAGE_BACKPUP = 44
+    @JvmStatic val REQUEST_EXTERNAL_STORAGE_BACKUP = 44
     @JvmStatic val REQUEST_EXTERNAL_STORAGE_RESTORE = 66
     @JvmStatic val PERMISSIONS_STORAGE = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     ext.kotlin_version = '1.8.0'
     repositories {
         jcenter()
+        mavenCentral()
         google()
     }
     dependencies {
@@ -17,6 +18,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
Since [anko](https://github.com/Kotlin/anko/blob/master/GOODBYE.md) is deprecated, I replaced it with alternatives (except for the sqlite dependency).

Main changes:
- Replace anko alert with splitties [alertDialog AppCompat](https://splitties.louiscad.com/modules/alertdialog-appcompat/)
- Replace anko defaultSharedPreferences with androidx.preference PreferenceManager
- Replace anko doAsync with kotlinx.coroutines async
- In prefsActivity: use onpreferenceTreeClick
- Change behavior of alerts at the end of a quiz: now no longer cancellable (when clicking on some other part of the screen) to prevent user from accidentally leaving the quiz. 

Small changes:
- Replace anko methods: find -> findViewById, withArguments -> Bundle, intentFor -> Intent, toast -> Toast.makeText
- In prefsActivity: separate into functions getResetAlert and getDeleteVoicesAlert and use for loop for voice file deletion
- Suppress unused variable warning for variables with "by injector.instance()"
- Fix typo in util/Extras.kt