### PR TITLE
Upgrade deprecated methods

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation 'org.jetbrains.anko:anko-sqlite:0.10.6'
 
     // Splitties
-    implementation("com.louiscad.splitties:splitties-fun-pack-android-appcompat:3.0.0")
+    implementation("com.louiscad.splitties:splitties-alertdialog-appcompat:3.0.0")
 
     //firebase
     implementation platform('com.google.firebase:firebase-bom:31.2.3')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     implementation 'io.github.microutils:kotlin-logging:1.3.3'
     implementation group: 'org.slf4j', name: 'slf4j-android', version: '1.7.21'
 
-    //Kodein dependencies
-    implementation 'com.github.salomonbrys.kodein:kodein-android:3.1.0'
+    //Kodein dependencies   - note for 7.3.0 or higher: minSDK = 21
+    implementation 'org.kodein.di:kodein-di-framework-android-x:7.2.0'
 
     //Graphic libraries
     implementation 'com.flaviofaria:kenburnsview:1.0.7'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 android {
+    namespace 'com.jehutyno.yomikata'
+
     compileSdkVersion 33
     buildToolsVersion '29.0.3'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     implementation("androidx.viewpager2:viewpager2:1.0.0")
 
     // preference
-    implementation("androidx.preference:preference-ktx:1.1.0")
+    implementation("androidx.preference:preference-ktx:1.2.0")
 
     // coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation 'com.ms-square:expandableTextView:0.1.4'
     implementation 'io.github.inflationx:calligraphy3:3.1.1'
     implementation 'io.github.inflationx:viewpump:2.0.3'
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
 
     // preference
     implementation("androidx.preference:preference-ktx:1.1.0")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,11 +8,6 @@ android {
     namespace 'com.jehutyno.yomikata'
 
     compileSdkVersion 33
-    buildToolsVersion '29.0.3'
-
-    dexOptions {
-        jumboMode = true
-    }
 
     defaultConfig {
         applicationId "com.jehutyno.yomikata"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation 'com.ms-square:expandableTextView:0.1.4'
     implementation 'io.github.inflationx:calligraphy3:3.1.1'
     implementation 'io.github.inflationx:viewpump:2.0.3'
-    implementation("androidx.viewpager2:viewpager2:1.0.0")
+    implementation("androidx.viewpager2:viewpager2:1.1.0-beta01")
 
     // preference
     implementation("androidx.preference:preference-ktx:1.2.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          package="com.jehutyno.yomikata">
+          xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,14 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
+    <queries>
+        <package android:name="com.google.android.tts" />
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+        </intent>
+<!--        <provider android:authorities="..." />-->
+    </queries>
+
     <application
         android:name="com.jehutyno.yomikata.YomikataZKApplication"
         android:allowBackup="false"

--- a/app/src/main/kotlin/com/jehutyno/yomikata/ApplicationModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/ApplicationModule.kt
@@ -1,10 +1,10 @@
 package com.jehutyno.yomikata
 
 import android.content.Context
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
-
-fun applicationModule(context: Context) = Kodein.Module {
+fun applicationModule(context: Context) = DI.Module("applicationModule") {
     bind<Context>() with instance(context)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/YomikataZKApplication.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/YomikataZKApplication.kt
@@ -4,26 +4,26 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.multidex.MultiDexApplication
 import androidx.preference.PreferenceManager
 import com.facebook.stetho.Stetho
-import com.github.salomonbrys.kodein.*
 import com.jehutyno.yomikata.repository.*
 import com.jehutyno.yomikata.repository.local.*
 import com.jehutyno.yomikata.util.Prefs
 import io.github.inflationx.calligraphy3.CalligraphyConfig
 import io.github.inflationx.calligraphy3.CalligraphyInterceptor
 import io.github.inflationx.viewpump.ViewPump
+import org.kodein.di.*
 
 
 /**
  * Created by jehutyno on 25/09/2016.
  */
 
-class YomikataZKApplication : MultiDexApplication(), KodeinAware {
+class YomikataZKApplication : MultiDexApplication(), DIAware {
 
     companion object {
         val APP_PNAME = "com.jehutyno.yomikata"
     }
 
-    override val kodein: Kodein by Kodein.lazy {
+    override val di: DI by DI.lazy {
         import(repositoryModule())
         import(applicationModule(this@YomikataZKApplication))
         bind<QuizRepository>() with singleton { QuizSource(instance()) }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/FileChooserDialog.java
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/FileChooserDialog.java
@@ -21,11 +21,11 @@ import android.widget.TextView;
 import com.jehutyno.yomikata.R;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class FileChooserDialog extends AppCompatDialogFragment implements ItemHolder.OnItemClickListener, View.OnClickListener {
     private final static String KEY_CHOOSER_TYPE = "chooserType";
@@ -274,7 +274,7 @@ public class FileChooserDialog extends AppCompatDialogFragment implements ItemHo
         View view = inflater.inflate(R.layout.fragment_chooser, container, false);
         findViews(view);
         setListeners();
-        getDialog().setTitle(title);
+        Objects.requireNonNull(getDialog()).setTitle(title);
 
         if (chooserType == ChooserType.DIRECTORY_CHOOSER) {
             btnSelectDirectory.setVisibility(View.VISIBLE);
@@ -327,31 +327,29 @@ public class FileChooserDialog extends AppCompatDialogFragment implements ItemHo
         String currentDir = path.substring(path.lastIndexOf(File.separator) + 1);
         tvCurrentDirectory.setText(currentDir);
 
-        File[] files = new File(path).listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File file) {
-                if (file.canRead()) {
-                    if (chooserType == ChooserType.FILE_CHOOSER && file.isFile()) {
-                        if (fileFormats != null && fileFormats.length > 0) {
-                            for (String fileFormat : fileFormats) {
-                                if (file.getName().endsWith(fileFormat)) {
-                                    return true;
-                                }
+        File[] files = new File(path).listFiles(file -> {
+            if (file.canRead()) {
+                if (chooserType == ChooserType.FILE_CHOOSER && file.isFile()) {
+                    if (fileFormats != null && fileFormats.length > 0) {
+                        for (String fileFormat : fileFormats) {
+                            if (file.getName().endsWith(fileFormat)) {
+                                return true;
                             }
-                            return false;
                         }
-                        return true;
+                        return false;
                     }
-                    return file.isDirectory();
+                    return true;
                 }
-                return false;
+                return file.isDirectory();
             }
+            return false;
         });
 
         List<Item> items = new ArrayList<>();
+        assert files != null;
         for (File f : files) {
             int drawableId = f.isFile() ? fileIconId : directoryIconId;
-            Drawable drawable = ContextCompat.getDrawable(getActivity().getApplicationContext(), drawableId);
+            Drawable drawable = ContextCompat.getDrawable(requireActivity().getApplicationContext(), drawableId);
             items.add(new Item(f.getPath(), drawable));
         }
         Collections.sort(items);
@@ -361,6 +359,7 @@ public class FileChooserDialog extends AppCompatDialogFragment implements ItemHo
 
     private void getGivenArguments() {
         Bundle args = getArguments();
+        assert args != null;
         chooserType = (ChooserType) args.getSerializable(KEY_CHOOSER_TYPE);
         chooserListener = (ChooserListener) args.getSerializable(KEY_CHOOSER_LISTENER);
         title = args.getString(KEY_TITLE);

--- a/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/ItemHolder.java
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/ItemHolder.java
@@ -21,18 +21,13 @@ class ItemHolder extends RecyclerView.ViewHolder {
 
         this.itemClickListener = itemClickListener;
 
-        ivItemIcon = (ImageView) itemView.findViewById(R.id.item_icon_imageview);
-        tvItemName = (TextView) itemView.findViewById(R.id.item_name_textview);
+        ivItemIcon = itemView.findViewById(R.id.item_icon_imageview);
+        tvItemName = itemView.findViewById(R.id.item_name_textview);
     }
 
     void bind(final Item item) {
         tvItemName.setText(item.getName());
         ivItemIcon.setImageDrawable(item.getIcon());
-        itemView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                itemClickListener.onItemClick(item);
-            }
-        });
+        itemView.setOnClickListener(view -> itemClickListener.onItemClick(item));
     }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/ItemsAdapter.java
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/ItemsAdapter.java
@@ -1,9 +1,10 @@
 package com.jehutyno.yomikata.filechooser;
 
+import android.annotation.SuppressLint;
 import androidx.annotation.NonNull;
+
 import androidx.recyclerview.widget.RecyclerView;
 
-import android.annotation.SuppressLint;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/ItemsAdapter.java
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/filechooser/ItemsAdapter.java
@@ -1,6 +1,9 @@
 package com.jehutyno.yomikata.filechooser;
 
+import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.annotation.SuppressLint;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -18,11 +21,13 @@ class ItemsAdapter extends RecyclerView.Adapter<ItemHolder> {
         items = new ArrayList<>();
     }
 
+    @SuppressLint("NotifyDataSetChanged")
     public void setItems(List<Item> items) {
         this.items = items;
         notifyDataSetChanged();
     }
 
+    @NonNull
     @Override
     public ItemHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());

--- a/app/src/main/kotlin/com/jehutyno/yomikata/managers/ExoPlayerAudio.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/managers/ExoPlayerAudio.kt
@@ -3,6 +3,7 @@ package component
 import android.content.Context
 import android.net.Uri
 import android.os.Handler
+import android.os.Looper
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.ExoPlayerFactory
 import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer
@@ -16,7 +17,7 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory
 
 class ExoPlayerAudio(context: Context) {
 
-    private val handler = Handler()
+    private val handler = Handler(Looper.getMainLooper())
     private val rendererAudio = MediaCodecAudioRenderer(MediaCodecSelector.DEFAULT, handler, null)
     private val trackSelector = DefaultTrackSelector(DefaultBandwidthMeter())
     private val dataSourceFactory = DefaultDataSourceFactory(context, "UserAgent")

--- a/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManager.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManager.kt
@@ -27,17 +27,13 @@ class VoicesManager(val context: Activity) {
             val toast = Toast.makeText(context, R.string.message_adjuste_volume, Toast.LENGTH_LONG)
             toast.show()
         }
-        val speechAvailability = checkSpeechAvailability(context, ttsSupported, sentence.level)
-        when (speechAvailability) {
+        when (checkSpeechAvailability(context, ttsSupported, sentence.level)) {
             SpeechAvailability.VOICES_AVAILABLE -> {
                 try {
                     exoPlayer.prepare(exoPlayerAudio.extractorMediaSource(Uri.parse("${FileUtils.getDataDir(context, "Voices").absolutePath}/s_${sentence.id}.mp3")))
                     exoPlayer.playWhenReady = true
                 } catch (e: Exception) {
-                    if (speechAvailability == SpeechAvailability.TTS_AVAILABLE)
-                        tts?.speak(sentenceNoFuri(sentence), TextToSpeech.QUEUE_FLUSH, null)
-                    else
-                        speechNotSupportedAlert(context, sentence.level, {})
+                    speechNotSupportedAlert(context, sentence.level, {})
                 }
             }
             SpeechAvailability.TTS_AVAILABLE -> tts?.speak(sentenceNoFuri(sentence), TextToSpeech.QUEUE_FLUSH, null)
@@ -60,15 +56,7 @@ class VoicesManager(val context: Activity) {
                     exoPlayer.prepare(exoPlayerAudio.extractorMediaSource(Uri.parse("${FileUtils.getDataDir(context, "Voices").absolutePath}/w_${word.id}.mp3")))
                     exoPlayer.playWhenReady = true
                 } catch (e: Exception) {
-                    if (speechAvailability == SpeechAvailability.TTS_AVAILABLE) {
-                        tts?.speak(
-                            if (word.isKana >= 1)
-                                word.japanese.split("/")[0].split(";")[0]
-                            else
-                                word.reading.split("/")[0].split(";")[0],
-                            TextToSpeech.QUEUE_FLUSH, null)
-                    } else
-                        speechNotSupportedAlert(context, level, {})
+                    speechNotSupportedAlert(context, level, {})
                 }
             }
             SpeechAvailability.TTS_AVAILABLE -> {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManager.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManager.kt
@@ -39,7 +39,7 @@ class VoicesManager(val context: Activity) {
             }
             SpeechAvailability.TTS_AVAILABLE -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    tts?.speak(sentenceNoFuri(sentence), TextToSpeech.QUEUE_FLUSH, null,null)
+                    tts?.speak(sentenceNoFuri(sentence), TextToSpeech.QUEUE_FLUSH, null, null)
                 } else {    // remove this if minBuildVersion >= 21 (LOLLIPOP)
                     @Suppress("DEPRECATION")
                     tts?.speak(sentenceNoFuri(sentence), TextToSpeech.QUEUE_FLUSH, null)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManagerModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/managers/VoicesManagerModule.kt
@@ -1,13 +1,14 @@
 package com.jehutyno.yomikata.screens.answers
 
 import android.app.Activity
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.singleton
 import com.jehutyno.yomikata.managers.VoicesManager
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.singleton
 
 /**
  * Created by valentin on 25/10/2016.
  */
-fun voicesManagerModule(context: Activity) = Kodein.Module {
+fun voicesManagerModule(context: Activity) = DI.Module("voicesManagerModule") {
     bind<VoicesManager>() with singleton { VoicesManager(context) }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Answer.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Answer.kt
@@ -1,5 +1,6 @@
 package com.jehutyno.yomikata.model
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import com.jehutyno.yomikata.util.QuizType
@@ -8,9 +9,16 @@ import java.io.Serializable
 /**
  * Created by valentin on 25/10/2016.
  */
-open class Answer(val result: Int, var answer: String, val wordId: Long, val sentenceId: Long, val quizType: QuizType ) : Parcelable, Serializable {
+open class Answer(val result: Int, var answer: String, val wordId: Long, val sentenceId: Long, val quizType: QuizType) : Parcelable, Serializable {
 
-    constructor(source: Parcel): this(source.readInt(), source.readString()!!, source.readLong(), source.readLong(), source.readParcelable(QuizType::class.java.classLoader)!!)
+    constructor(source: Parcel) : this(source.readInt(), source.readString()!!, source.readLong(), source.readLong(),
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                source.readParcelable(QuizType::class.java.classLoader, QuizType::class.java)!!
+            }
+            else {
+                @Suppress("DEPRECATION")
+                source.readParcelable(QuizType::class.java.classLoader)!!
+            })
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
         dest.writeInt(result)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Answer.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Answer.kt
@@ -33,6 +33,7 @@ open class Answer(val result: Int, var answer: String, val wordId: Long, val sen
     }
 
     companion object {
+        @Suppress("UNUSED")
         @JvmField val CREATOR: Parcelable.Creator<Answer> = object : Parcelable.Creator<Answer> {
             override fun createFromParcel(source: Parcel): Answer {
                 return Answer(source)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/KanjiSolo.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/KanjiSolo.kt
@@ -9,10 +9,10 @@ open class KanjiSolo(val id: Long, val kanji: String, val strokes: Int, val en: 
                      val kunyomi: String, val onyomi: String, val radical: String) {
 
     fun getTrad(): String {
-        if (Locale.getDefault().language == "fr")
-            return fr
+        return if (Locale.getDefault().language == "fr")
+            fr
         else
-            return en
+            en
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/KanjiSoloRadical.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/KanjiSoloRadical.kt
@@ -10,10 +10,10 @@ open class KanjiSoloRadical(id: Long, kanji: String, strokes: Int, en: String, f
                             val radEn: String, val radFr: String): KanjiSolo(id, kanji, strokes, en, fr, kunyomi, onyomi, radical){
 
     fun getRadTrad(): String {
-        if (Locale.getDefault().language == "fr")
-            return radFr
+        return if (Locale.getDefault().language == "fr")
+            radFr
         else
-            return radEn
+            radEn
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Quiz.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Quiz.kt
@@ -8,10 +8,10 @@ import java.util.*
 open class Quiz(val id: Long, var nameEn: String, var nameFr: String, val category: Int, var isSelected: Int) {
 
     fun getName(): String {
-        if (Locale.getDefault().language == "fr")
-            return nameFr
+        return if (Locale.getDefault().language == "fr")
+            nameFr
         else
-            return nameEn
+            nameEn
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Radical.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Radical.kt
@@ -8,10 +8,10 @@ import java.util.*
 open class Radical(val id: Long, val strokes: Int, val radical: String, val reading: String, val en: String, val fr: String) {
 
     fun getTrad(): String {
-        if (Locale.getDefault().language == "fr")
-            return fr
+        return if (Locale.getDefault().language == "fr")
+            fr
         else
-            return en
+            en
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Sentence.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Sentence.kt
@@ -25,6 +25,7 @@ open class Sentence(var id: Long = -1, val jap: String = "", val en: String = ""
     }
 
     companion object {
+        @Suppress("UNUSED")
         @JvmField val CREATOR: Parcelable.Creator<Sentence> = object : Parcelable.Creator<Sentence> {
             override fun createFromParcel(source: Parcel): Sentence{
                 return Sentence(source)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Sentence.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Sentence.kt
@@ -39,9 +39,9 @@ open class Sentence(var id: Long = -1, val jap: String = "", val en: String = ""
 
     fun getTrad(): String {
         return if (Locale.getDefault().language == "fr")
-            fr!!
+            fr
         else
-            en!!
+            en
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/model/Word.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/model/Word.kt
@@ -45,6 +45,7 @@ open class Word(var id: Long, var japanese: String, var english: String, var fre
     }
 
     companion object {
+        @Suppress("UNUSED")
         @JvmField val CREATOR: Parcelable.Creator<Word> = object : Parcelable.Creator<Word> {
             override fun createFromParcel(source: Parcel): Word{
                 return Word(source)
@@ -57,10 +58,10 @@ open class Word(var id: Long, var japanese: String, var english: String, var fre
     }
 
     fun getTrad(): String {
-        if (Locale.getDefault().language == "fr")
-            return french
+        return if (Locale.getDefault().language == "fr")
+            french
         else
-            return english
+            english
     }
 }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/RepositoryModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/RepositoryModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.repository
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
-import com.github.salomonbrys.kodein.singleton
 import com.jehutyno.yomikata.repository.local.*
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
+import org.kodein.di.singleton
 
-fun repositoryModule() = Kodein.Module {
+fun repositoryModule() = DI.Module("repositoryModule") {
     bind<QuizRepository>("Local") with singleton { QuizSource(instance()) }
     bind<WordRepository>("Local") with singleton { WordSource(instance()) }
     bind<StatsRepository>("Local") with singleton { StatsSource(instance()) }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/StatsRepository.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/StatsRepository.kt
@@ -1,6 +1,5 @@
 package com.jehutyno.yomikata.repository
 
-import androidx.annotation.NonNull
 import com.jehutyno.yomikata.model.StatAction
 import com.jehutyno.yomikata.model.StatEntry
 import com.jehutyno.yomikata.model.StatResult
@@ -16,10 +15,10 @@ interface StatsRepository {
         fun onDataNotAvailable()
     }
     fun addStatEntry(action: StatAction, associatedId: Long, date: Long, result: StatResult)
-    fun getTodayStatEntries(today: Calendar, @NonNull callback: LoadStatsCallback)
-    fun getThisWeekStatEntries(today: Calendar, @NonNull callback: LoadStatsCallback)
-    fun getThisMonthStatEntries(today: Calendar, @NonNull callback: LoadStatsCallback)
-    fun getAllStatEntries(@NonNull callback: StatsRepository.LoadStatsCallback)
+    fun getTodayStatEntries(today: Calendar, callback: LoadStatsCallback)
+    fun getThisWeekStatEntries(today: Calendar, callback: LoadStatsCallback)
+    fun getThisMonthStatEntries(today: Calendar, callback: LoadStatsCallback)
+    fun getAllStatEntries(callback: StatsRepository.LoadStatsCallback)
     fun removeAllStats()
     fun addStatEntry(entry: StatEntry)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/WordRepository.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/WordRepository.kt
@@ -1,7 +1,6 @@
 package com.jehutyno.yomikata.repository
 
 import android.database.sqlite.SQLiteDatabase
-import androidx.annotation.NonNull
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.repository.migration.WordTable
 import com.jehutyno.yomikata.util.QuizType
@@ -19,13 +18,13 @@ interface WordRepository {
         fun onWordsLoaded(task:Word)
         fun onDataNotAvailable()
     }
-    fun getWords(quizId: Long, @NonNull callback:LoadWordsCallback)
-    fun getWords(quizIds: LongArray, @NonNull callback:LoadWordsCallback)
-    fun searchWords(searchString: String, @NonNull callback:LoadWordsCallback)
-    fun saveWord(@NonNull task:Word)
+    fun getWords(quizId: Long, callback:LoadWordsCallback)
+    fun getWords(quizIds: LongArray, callback:LoadWordsCallback)
+    fun searchWords(searchString: String, callback:LoadWordsCallback)
+    fun saveWord(task:Word)
     fun refreshWords()
     fun deleteAllWords()
-    fun deleteWord(@NonNull wordId:String)
+    fun deleteWord(wordId:String)
     fun isWordInQuiz(wordId:Long, quizId:Long) : Boolean
     fun isWordInQuizzes(wordId: Long, quizIds: Array<Long>) : ArrayList<Boolean>
     fun updateWordLevel(wordId: Long, level: Int)
@@ -34,7 +33,7 @@ interface WordRepository {
     fun getWordsByRepetition(quizIds: LongArray, repetition: Int, limit: Int): ArrayList<Word>
     fun updateWordRepetition(wordId: Long, repetition: Int)
     fun decreaseWordsRepetition(quizIds: LongArray)
-    fun restoreWord(word: String, prononciation: String, wordTable: WordTable)
+    fun restoreWord(word: String, pronunciation: String, wordTable: WordTable)
     fun updateWordSelected(id: Long, check: Boolean)
     fun getWordsByLevel(quizIds: LongArray, level: Int, callback: LoadWordsCallback)
     fun getAllWords(db: SQLiteDatabase?) : List<Word>

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/KanjiSoloSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/KanjiSoloSource.kt
@@ -137,7 +137,7 @@ class KanjiSoloSource(var context: Context) : KanjiSoloRepository {
 
     override fun getSoloByKanjiRadical(kanji: String): KanjiSoloRadical? {
         var radical: KanjiSoloRadical? = null
-        var query = "select ${SQLiteTables.KANJI_SOLO.tableName}.${SQLiteTable.allColumns(SQLiteKanjiSolo.values()).joinToString(",${SQLiteTables.KANJI_SOLO.tableName}.")}," +
+        val query = "select ${SQLiteTables.KANJI_SOLO.tableName}.${SQLiteTable.allColumns(SQLiteKanjiSolo.values()).joinToString(",${SQLiteTables.KANJI_SOLO.tableName}.")}," +
             "${SQLiteTables.RADICALS.tableName}.${SQLiteRadicals.STROKES.column}," +
             "${SQLiteTables.RADICALS.tableName}.${SQLiteRadicals.READING.column}," +
             "${SQLiteTables.RADICALS.tableName}.${SQLiteRadicals.EN.column}," +

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/KanjiSoloSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/KanjiSoloSource.kt
@@ -123,7 +123,7 @@ class KanjiSoloSource(var context: Context) : KanjiSoloRepository {
         var radical: KanjiSolo? = null
         context.database.use {
             select(SQLiteTables.KANJI_SOLO.tableName, *SQLiteTable.allColumns(SQLiteKanjiSolo.values()))
-                .where("${SQLiteKanjiSolo.KANJI.column} = '$kanji'")
+                .whereArgs("${SQLiteKanjiSolo.KANJI.column} = '$kanji'")
                 .exec {
                     if (count == 1) {
                         moveToFirst()
@@ -164,7 +164,7 @@ class KanjiSoloSource(var context: Context) : KanjiSoloRepository {
         var radical: Radical? = null
         context.database.use {
             select(SQLiteTables.RADICALS.tableName, *SQLiteTable.allColumns(SQLiteRadicals.values()))
-                .where("${SQLiteRadicals.RADICAL.column} = '$radicalString'")
+                .whereArgs("${SQLiteRadicals.RADICAL.column} = '$radicalString'")
                 .exec {
                     if (count == 1) {
                         moveToFirst()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/QuizSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/QuizSource.kt
@@ -17,7 +17,7 @@ class QuizSource(var context: Context) : QuizRepository {
     override fun getQuiz(category: Int, callback: QuizRepository.LoadQuizCallback) {
         context.database.use {
             select(SQLiteTables.QUIZ.tableName, *SQLiteTable.allColumns(SQLiteQuiz.values()))
-                .where("${SQLiteQuiz.CATEGORY.column} = $category")
+                .whereArgs("${SQLiteQuiz.CATEGORY.column} = $category")
                 .exec {
                     val rowParser = rowParser(::Quiz)
                     if (count > 0)
@@ -31,7 +31,7 @@ class QuizSource(var context: Context) : QuizRepository {
     override fun getQuiz(quizId: Long, callback: QuizRepository.GetQuizCallback) {
         context.database.use {
             select(SQLiteTables.QUIZ.tableName, *SQLiteTable.allColumns(SQLiteQuiz.values()))
-                .where("${SQLiteQuiz.ID.column} = $quizId").limit(1)
+                .whereArgs("${SQLiteQuiz.ID.column} = $quizId").limit(1)
                 .exec {
                     val rowParser = rowParser(::Quiz)
                     if (count > 0)
@@ -46,7 +46,7 @@ class QuizSource(var context: Context) : QuizRepository {
         var quiz : Quiz? = null
         context.database.use {
             select(SQLiteTables.QUIZ.tableName, *SQLiteTable.allColumns(SQLiteQuiz.values()))
-                .where("${SQLiteQuiz.ID.column} = $quizId").limit(1)
+                .whereArgs("${SQLiteQuiz.ID.column} = $quizId").limit(1)
                 .exec {
                     val rowParser = rowParser(::Quiz)
                     if (count > 0)
@@ -117,7 +117,7 @@ class QuizSource(var context: Context) : QuizRepository {
 
     override fun countWordsForLevel(quizIds: LongArray, level: Int): Int {
         var count = 0
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} in (${quizIds.joinToString(",")}) " +
@@ -134,7 +134,7 @@ class QuizSource(var context: Context) : QuizRepository {
 
     override fun countWordsForQuizzes(quizIds: LongArray): Int {
         var count = 0
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} in (${quizIds.joinToString(",")})"

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/SQLiteHelper.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/SQLiteHelper.kt
@@ -15,7 +15,7 @@ import java.io.IOException
  */
 class SQLiteHelper(var context: Context) : ManagedSQLiteOpenHelper(context, SQLiteHelper.DATABASE_NAME, null, SQLiteHelper.DATABASE_VERSION) {
 
-    lateinit private var database: SQLiteDatabase
+    private lateinit var database: SQLiteDatabase
     private var flag: Boolean = false
 
     companion object {
@@ -78,9 +78,7 @@ class SQLiteHelper(var context: Context) : ManagedSQLiteOpenHelper(context, SQLi
         } catch (e: SQLiteException) {
             e.printStackTrace()
         }
-        if (checkDB != null) {
-            checkDB.close()
-        }
+        checkDB?.close()
 
         return checkDB != null
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/SentenceSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/SentenceSource.kt
@@ -61,8 +61,8 @@ class SentenceSource(var context: Context) : SentenceRepository {
     override fun getSentenceById(id: Long): Sentence {
         var sentence: Sentence? = null
         context.database.use {
-            select(SQLiteTables.SENTENCES.tableName).where(
-                "${SQLiteSentences.ID.column} = $id").limit(1).exec {
+            select(SQLiteTables.SENTENCES.tableName).whereArgs(
+                    "${SQLiteSentences.ID.column} = $id").limit(1).exec {
                 sentence = parseSingle(getSentencesParser())
             }
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/SentenceSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/SentenceSource.kt
@@ -90,17 +90,17 @@ class SentenceSource(var context: Context) : SentenceRepository {
 
     override fun updateSentence(updateSentence: Sentence, sentence: Sentence?) {
         context.database.use {
-            if (sentence != null && updateSentence.jap != sentence!!.jap) {
+            if (sentence != null && updateSentence.jap != sentence.jap) {
                 update(SQLiteTables.SENTENCES.tableName,
                     SQLiteSentences.JAP.column to updateSentence.jap).whereArgs(
                     "${SQLiteSentences.ID.column} = '${updateSentence.id}'").exec()
             }
-            if (sentence != null && updateSentence.en != sentence!!.en) {
+            if (sentence != null && updateSentence.en != sentence.en) {
                 update(SQLiteTables.SENTENCES.tableName,
                     SQLiteSentences.EN.column to updateSentence.en).whereArgs(
                     "${SQLiteSentences.ID.column} = '${updateSentence.id}'").exec()
             }
-            if (sentence != null && updateSentence.fr != sentence!!.fr) {
+            if (sentence != null && updateSentence.fr != sentence.fr) {
                 update(SQLiteTables.SENTENCES.tableName,
                     SQLiteSentences.FR.column to updateSentence.fr).whereArgs(
                     "${SQLiteSentences.ID.column} = '${updateSentence.id}'").exec()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/StatsSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/StatsSource.kt
@@ -62,7 +62,7 @@ class StatsSource(var context: Context) : StatsRepository {
         val startEnd = getStartEndOFWeek(today)
         context.database.use {
             select(SQLiteTables.STAT_ENTRY.tableName, *SQLiteTable.allColumns(SQLiteStatEntry.values()))
-                .where("${SQLiteStatEntry.DATE} > ${startEnd[0]} AND ${SQLiteStatEntry.DATE} < ${startEnd[1]}")
+                .whereArgs("${SQLiteStatEntry.DATE} > ${startEnd[0]} AND ${SQLiteStatEntry.DATE} < ${startEnd[1]}")
                 .exec {
                     val rowParser = rowParser(::StatEntry)
                     callback.onStatsLoaded(StatTime.THIS_WEEK, parseList(rowParser))
@@ -74,7 +74,7 @@ class StatsSource(var context: Context) : StatsRepository {
         val startEnd = getStartEndOfMonth(today)
         context.database.use {
             select(SQLiteTables.STAT_ENTRY.tableName, *SQLiteTable.allColumns(SQLiteStatEntry.values()))
-                .where("${SQLiteStatEntry.DATE} > ${startEnd[0]} AND ${SQLiteStatEntry.DATE} < ${startEnd[1]}")
+                .whereArgs("${SQLiteStatEntry.DATE} > ${startEnd[0]} AND ${SQLiteStatEntry.DATE} < ${startEnd[1]}")
                 .exec {
                     val rowParser = rowParser(::StatEntry)
                     callback.onStatsLoaded(StatTime.THIS_MONTH, parseList(rowParser))

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/StatsSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/StatsSource.kt
@@ -47,7 +47,7 @@ class StatsSource(var context: Context) : StatsRepository {
         val start = today.timeInMillis
         today.set(Calendar.HOUR_OF_DAY, 23)
         today.set(Calendar.MINUTE, 59)
-        val end = today.timeInMillis;
+        val end = today.timeInMillis
         context.database.use {
             select(SQLiteTables.STAT_ENTRY.tableName, *SQLiteTable.allColumns(SQLiteStatEntry.values()))
                 .whereArgs("${SQLiteStatEntry.DATE} > $start AND ${SQLiteStatEntry.DATE} < $end")

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/UpdateSQLiteHelper.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/UpdateSQLiteHelper.kt
@@ -16,7 +16,7 @@ import java.io.IOException
  */
 class UpdateSQLiteHelper(var context: Context, val filePath: String) : ManagedSQLiteOpenHelper(context, UpdateSQLiteHelper.UPDATE_DATABASE_NAME, null, DATABASE_VERSION) {
 
-    lateinit private var database: SQLiteDatabase
+    private lateinit var database: SQLiteDatabase
     private var flag: Boolean = false
 
     companion object {
@@ -79,9 +79,7 @@ class UpdateSQLiteHelper(var context: Context, val filePath: String) : ManagedSQ
         } catch (e: SQLiteException) {
             e.printStackTrace()
         }
-        if (checkDB != null) {
-            checkDB.close()
-        }
+        checkDB?.close()
 
         return checkDB != null
     }
@@ -94,7 +92,7 @@ class UpdateSQLiteHelper(var context: Context, val filePath: String) : ManagedSQ
     @Throws(IOException::class)
     private fun copyDataBase() {
         // Open your local db as the input stream
-        val myInput = if (!filePath.isEmpty())
+        val myInput = if (filePath.isNotEmpty())
             File(filePath).inputStream()
         else
             context.assets.open(SQLiteHelper.DATABASE_NAME)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/UpdateSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/UpdateSource.kt
@@ -38,7 +38,7 @@ class UpdateSource(private var context: Context, private val filePath: String) {
         var quizWord = listOf<QuizWord>()
         UpdateSQLiteHelper.getInstance(context, filePath).use {
             select(SQLiteTables.QUIZ_WORD.tableName, *SQLiteTable.allColumns(SQLiteQuizWord.values()))
-                    .where("${SQLiteQuizWord.ID.column} > 7504")
+                    .whereArgs("${SQLiteQuizWord.ID.column} > 7504")
                     .exec {
                         quizWord = parseList(rowParser(::QuizWord))
                     }
@@ -50,7 +50,7 @@ class UpdateSource(private var context: Context, private val filePath: String) {
         var quizzes = listOf<Quiz>()
         UpdateSQLiteHelper.getInstance(context, filePath).use {
             select(SQLiteTables.QUIZ.tableName, *SQLiteTable.allColumns(SQLiteQuiz.values()))
-                    .where("${SQLiteQuiz.ID.column} > 96")
+                    .whereArgs("${SQLiteQuiz.ID.column} > 96")
                     .exec {
                         quizzes = parseList(rowParser(::Quiz))
                     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/UpdateSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/UpdateSource.kt
@@ -10,7 +10,7 @@ import org.jetbrains.anko.db.select
 /**
  * Created by jehutyno on 08/10/2016.
  */
-class UpdateSource(var context: Context, val filePath: String) {
+class UpdateSource(private var context: Context, private val filePath: String) {
 
     fun getAllWords(): List<Word> {
         var words = listOf<Word>()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
@@ -314,9 +314,17 @@ class WordSource(var context: Context) : WordRepository {
 
         context.database.use {
             val cursor = rawQuery(query, null)
+            val repetitionCursorIndex = cursor.getColumnIndex(SQLiteWord.REPETITION.column)
+            if (repetitionCursorIndex == -1) { // could not find column
+                throw Error("could not find column REPETITION: ${SQLiteWord.REPETITION.column}")
+            }
+            val idCursorIndex = cursor.getColumnIndex(SQLiteWord.ID.column)
+            if (idCursorIndex == -1) {
+                throw Error("could not find column ID: ${SQLiteWord.ID.column}")
+            }
             while (cursor.moveToNext()) {
-                update(SQLiteTables.WORDS.tableName, SQLiteWord.REPETITION.column to cursor.getInt(cursor.getColumnIndex(SQLiteWord.REPETITION.column)) - 1)
-                    .where("${SQLiteWord.ID.column} = {id}", "id" to cursor.getLong(cursor.getColumnIndex(SQLiteWord.ID.column)))
+                update(SQLiteTables.WORDS.tableName, SQLiteWord.REPETITION.column to cursor.getInt(repetitionCursorIndex) - 1)
+                    .whereArgs("${SQLiteWord.ID.column} = {id}", "id" to cursor.getLong(idCursorIndex))
                     .exec()
             }
             cursor.close()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
@@ -205,8 +205,7 @@ class WordSource(var context: Context) : WordRepository {
         val hiragana = HiraganaUtils.toHiragana(searchString)
         context.database.use {
             select(SQLiteTables.WORDS.tableName, *SQLiteTable.allColumns(SQLiteWord.values()))
-                .where(
-                    "${SQLiteWord.READING} LIKE '%$searchString%'" +
+                .whereArgs("${SQLiteWord.READING} LIKE '%$searchString%'" +
                         " or ${SQLiteWord.READING} LIKE '%$hiragana%'" +
                         " or ${SQLiteWord.JAPANESE} LIKE '%$searchString%'" +
                         " or ${SQLiteWord.JAPANESE} LIKE '%$hiragana%'" +
@@ -231,9 +230,9 @@ class WordSource(var context: Context) : WordRepository {
     override fun isWordInQuiz(wordId: Long, quizId: Long): Boolean {
         var ret = false
         context.database.use {
-            select(SQLiteTables.QUIZ_WORD.tableName).where(
-                "${SQLiteQuizWord.WORD_ID.column} = $wordId AND " +
-                    "${SQLiteQuizWord.QUIZ_ID.column} = $quizId").exec {
+            select(SQLiteTables.QUIZ_WORD.tableName).whereArgs(
+                    "${SQLiteQuizWord.WORD_ID.column} = $wordId AND " +
+                            "${SQLiteQuizWord.QUIZ_ID.column} = $quizId").exec {
                 ret = count > 0
             }
         }
@@ -244,9 +243,9 @@ class WordSource(var context: Context) : WordRepository {
         val ret: ArrayList<Boolean> = arrayListOf()
         context.database.use {
             for (quizId in quizIds) {
-                select(SQLiteTables.QUIZ_WORD.tableName).where(
-                    "${SQLiteQuizWord.WORD_ID.column} = $wordId AND " +
-                        "${SQLiteQuizWord.QUIZ_ID.column} = $quizId").exec {
+                select(SQLiteTables.QUIZ_WORD.tableName).whereArgs(
+                        "${SQLiteQuizWord.WORD_ID.column} = $wordId AND " +
+                                "${SQLiteQuizWord.QUIZ_ID.column} = $quizId").exec {
                     ret.add(count > 0)
                 }
             }
@@ -258,8 +257,8 @@ class WordSource(var context: Context) : WordRepository {
     override fun getWordById(wordId: Long): Word {
         var word: Word? = null
         context.database.use {
-            select(SQLiteTables.WORDS.tableName).where(
-                "${SQLiteWord.ID.column} = $wordId").exec {
+            select(SQLiteTables.WORDS.tableName).whereArgs(
+                    "${SQLiteWord.ID.column} = $wordId").exec {
                 word = parseSingle(getWordsParser())
             }
         }
@@ -302,7 +301,7 @@ class WordSource(var context: Context) : WordRepository {
     override fun updateWordRepetition(wordId: Long, repetition: Int) {
         context.database.use {
             update(SQLiteTables.WORDS.tableName, SQLiteWord.REPETITION.column to repetition)
-                .where("${SQLiteWord.ID.column} = {wordId}", "wordId" to wordId)
+                .whereArgs("${SQLiteWord.ID.column} = {wordId}", "wordId" to wordId)
                 .exec()
         }
     }
@@ -399,37 +398,37 @@ class WordSource(var context: Context) : WordRepository {
         context.database.use {
             if (word != null && updateWord.countFail > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.COUNT_FAIL.column to updateWord.countFail).where(
-                    "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
+                    SQLiteWord.COUNT_FAIL.column to updateWord.countFail).whereArgs(
+                  "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
             if (word != null && updateWord.countSuccess > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.COUNT_SUCCESS.column to updateWord.countSuccess).where(
+                    SQLiteWord.COUNT_SUCCESS.column to updateWord.countSuccess).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
             if (word != null && updateWord.countTry > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.COUNT_TRY.column to updateWord.countTry).where(
+                    SQLiteWord.COUNT_TRY.column to updateWord.countTry).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
             if (word != null && updateWord.isSelected > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.IS_SELECTED.column to updateWord.isSelected).where(
+                    SQLiteWord.IS_SELECTED.column to updateWord.isSelected).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
             if (word != null && updateWord.level > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.LEVEL.column to updateWord.level).where(
+                    SQLiteWord.LEVEL.column to updateWord.level).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
             if (word != null && updateWord.points > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.POINTS.column to updateWord.points).where(
+                    SQLiteWord.POINTS.column to updateWord.points).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
             if (word != null && updateWord.repetition > 0) {
                 update(SQLiteTables.WORDS.tableName,
-                    SQLiteWord.REPETITION.column to updateWord.repetition).where(
+                    SQLiteWord.REPETITION.column to updateWord.repetition).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
 
@@ -456,7 +455,7 @@ class WordSource(var context: Context) : WordRepository {
         var quizWord: QuizWord? = null
         context.database.use {
             select(SQLiteTables.QUIZ_WORD.tableName)
-                .where("${SQLiteQuizWord.QUIZ_ID.column} = $quizId and ${SQLiteQuizWord.WORD_ID.column} = $wordId")
+                .whereArgs("${SQLiteQuizWord.QUIZ_ID.column} = $quizId and ${SQLiteQuizWord.WORD_ID.column} = $wordId")
                 .exec {
                     if (count > 0)
                         quizWord = parseSingle(rowParser(::QuizWord))

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
@@ -350,27 +350,27 @@ class WordSource(var context: Context) : WordRepository {
 
     override fun updateWord(updateWord: Word, word: Word?) {
         context.database.use {
-            if (word != null && updateWord.japanese != word!!.japanese) {
+            if (word != null && updateWord.japanese != word.japanese) {
                 update(SQLiteTables.WORDS.tableName,
                     SQLiteWord.JAPANESE.column to updateWord.japanese).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
-            if (word != null && updateWord.english != word!!.english) {
+            if (word != null && updateWord.english != word.english) {
                 update(SQLiteTables.WORDS.tableName,
                     SQLiteWord.ENGLISH.column to updateWord.english).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
-            if (word != null && updateWord.french != word!!.french) {
+            if (word != null && updateWord.french != word.french) {
                 update(SQLiteTables.WORDS.tableName,
                     SQLiteWord.FRENCH.column to updateWord.french).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
-            if (word != null && updateWord.reading != word!!.reading) {
+            if (word != null && updateWord.reading != word.reading) {
                 update(SQLiteTables.WORDS.tableName,
                     SQLiteWord.READING.column to updateWord.reading).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()
             }
-            if (word != null && updateWord.sentenceId != word!!.sentenceId) {
+            if (word != null && updateWord.sentenceId != word.sentenceId) {
                 update(SQLiteTables.WORDS.tableName,
                     SQLiteWord.SENTENCE_ID.column to updateWord.sentenceId).whereArgs(
                     "${SQLiteWord.ID.column} = '${updateWord.id}'").exec()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
@@ -78,7 +78,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun getWords(quizId: Long, callback: WordRepository.LoadWordsCallback) {
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} = $quizId"
@@ -96,7 +96,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun getWords(quizIds: LongArray, callback: WordRepository.LoadWordsCallback) {
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} in (${quizIds.joinToString(",")})"
@@ -113,7 +113,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun getWordsByLevel(quizIds: LongArray, level: Int, callback: WordRepository.LoadWordsCallback) {
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} in (${quizIds.joinToString(",")}) " +
@@ -135,8 +135,8 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun getWordsByRepetition(quizIds: LongArray, repetition: Int, limit: Int): ArrayList<Word> {
-        var words = arrayListOf<Word>()
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
+        val words = arrayListOf<Word>()
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteTable.allColumns(SQLiteWord.values()).joinToString(",")} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} in (${quizIds.joinToString(",")}) " +
@@ -152,7 +152,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun getRandomWords(wordId: Long, answer: String, wordSize: Int, limit: Int, quizType: QuizType): ArrayList<Word> {
-        var words = arrayListOf<Word>()
+        val words = arrayListOf<Word>()
         val column = when(quizType) {
             QuizType.TYPE_PRONUNCIATION -> "${SQLiteTables.WORDS.tableName}.${SQLiteWord.READING.column}"
             QuizType.TYPE_PRONUNCIATION_QCM -> "${SQLiteTables.WORDS.tableName}.${SQLiteWord.READING.column}"
@@ -202,7 +202,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun searchWords(searchString: String, callback: WordRepository.LoadWordsCallback) {
-        var hiragana = HiraganaUtils.toHiragana(searchString)
+        val hiragana = HiraganaUtils.toHiragana(searchString)
         context.database.use {
             select(SQLiteTables.WORDS.tableName, *SQLiteTable.allColumns(SQLiteWord.values()))
                 .where(
@@ -241,7 +241,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun isWordInQuizzes(wordId: Long, quizIds: Array<Long>): ArrayList<Boolean> {
-        var ret: ArrayList<Boolean> = arrayListOf()
+        val ret: ArrayList<Boolean> = arrayListOf()
         context.database.use {
             for (quizId in quizIds) {
                 select(SQLiteTables.QUIZ_WORD.tableName).where(
@@ -308,7 +308,7 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun decreaseWordsRepetition(quizIds: LongArray) {
-        var query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column},${SQLiteTables.WORDS.tableName}.${SQLiteWord.REPETITION.column} " +
+        val query = "select ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column},${SQLiteTables.WORDS.tableName}.${SQLiteWord.REPETITION.column} " +
             "from ${SQLiteTables.WORDS.tableName} join ${SQLiteTables.QUIZ_WORD.tableName} " +
             "ON ${SQLiteQuizWord.WORD_ID.column} = ${SQLiteTables.WORDS.tableName}.${SQLiteWord.ID.column} " +
             "and ${SQLiteQuizWord.QUIZ_ID.column} in (${quizIds.joinToString(",")}) and ${SQLiteWord.REPETITION.column} > 0"
@@ -325,13 +325,13 @@ class WordSource(var context: Context) : WordRepository {
     }
 
     override fun restoreWord(word: String, prononciation: String, wordTable: WordTable) {
-        var points = when (wordTable.priority) {
+        val points = when (wordTable.priority) {
             1 -> 75
             2 -> 50
             3 -> 100
             else -> 0
         }
-        var priority = when (wordTable.priority) {
+        val priority = when (wordTable.priority) {
             1 -> 0
             else -> wordTable.priority
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/local/WordSource.kt
@@ -51,12 +51,13 @@ class WordSource(var context: Context) : WordRepository {
             "${SQLiteWord.IS_SELECTED.column} FROM OLD_${SQLiteTables.WORDS.tableName}"
 
         val query3 = "DROP TABLE OLD_${SQLiteTables.WORDS.tableName}"
-            context.database.use {
-                execSQL(query0)
-                execSQL(query1)
-                execSQL(query2)
-                execSQL(query3)
-            }
+
+        context.database.use {
+            execSQL(query0)
+            execSQL(query1)
+            execSQL(query2)
+            execSQL(query3)
+        }
     }
 
     override fun getAllWords(db: SQLiteDatabase?): List<Word> {
@@ -331,7 +332,7 @@ class WordSource(var context: Context) : WordRepository {
         }
     }
 
-    override fun restoreWord(word: String, prononciation: String, wordTable: WordTable) {
+    override fun restoreWord(word: String, pronunciation: String, wordTable: WordTable) {
         val points = when (wordTable.priority) {
             1 -> 75
             2 -> 50
@@ -351,7 +352,7 @@ class WordSource(var context: Context) : WordRepository {
                 SQLiteWord.COUNT_TRY.column to wordTable.counterTry,
                 SQLiteWord.COUNT_SUCCESS.column to wordTable.counterSuccess).whereArgs(
                 "${SQLiteWord.JAPANESE.column} = '$word' AND " +
-                    "${SQLiteWord.READING.column} LIKE '%$prononciation%'").exec()
+                    "${SQLiteWord.READING.column} LIKE '%$pronunciation%'").exec()
         }
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/migration/DatabaseHelper.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/migration/DatabaseHelper.kt
@@ -10,7 +10,7 @@ import org.jetbrains.anko.db.ManagedSQLiteOpenHelper
  */
 class DatabaseHelper(var context: Context, val dbName: String, val path: String) : ManagedSQLiteOpenHelper(context, dbName, null, Companion.DATABASE_VERSION) {
 
-    lateinit private var database: SQLiteDatabase
+    private lateinit var database: SQLiteDatabase
     private var flag: Boolean = false
 
     companion object {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/migration/MigrationSource.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/migration/MigrationSource.kt
@@ -12,7 +12,7 @@ import java.util.*
 class MigrationSource(var context: Context, val database: DatabaseHelper) {
 
     fun getWordTable(tableName: String) : ArrayList<WordTable> {
-        var wordTables = arrayListOf<WordTable>()
+        val wordTables = arrayListOf<WordTable>()
         database.use {
             select(tableName, *MigrationTable.allColumns(MigrationWordTable.values()))
                 .exec {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/repository/migration/WordTable.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/repository/migration/WordTable.kt
@@ -3,6 +3,5 @@ package com.jehutyno.yomikata.repository.migration
 /**
  * Created by valentin on 01/12/2016.
  */
-class WordTable(var id: Int, var word: String, var prononciation: String,
-                var counterTry: Int, var counterSuccess: Int, var counterFail: Int, var priority: Int) {
-}
+class WordTable(var id: Int, var word: String, var pronunciation: String,
+                var counterTry: Int, var counterSuccess: Int, var counterFail: Int, var priority: Int)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -229,6 +229,7 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
 
 
             val progressBar = ProgressBar(this, null, android.R.style.Widget_ProgressBar_Horizontal)
+            progressBar.setPadding(40, progressBar.paddingTop, 40, progressBar.paddingBottom)
             progressBar.max = wordTables.count()
 
             val progressAlertDialog = alertDialog {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -241,12 +241,12 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
 
             MainScope().async {
                 wordTables.forEach {
-                    val wordtable = migrationSource.getWordTable(it)
+                    val wordTable = migrationSource.getWordTable(it)
                     progressBar.incrementProgressBy(1)
-                    wordtable.forEach {word ->
+                    wordTable.forEach { word ->
                         val source = WordSource(this@PrefsActivity)
                         if (word.counterTry > 0 || word.priority > 0)
-                            source.restoreWord(word.word, word.prononciation, word)
+                            source.restoreWord(word.word, word.pronunciation, word)
                     }
                 }
                 File(toPath + toName).delete()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -1,11 +1,11 @@
 package com.jehutyno.yomikata.screens
 
 import android.Manifest
-import android.app.ProgressDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -227,18 +227,22 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
             val migrationSource = MigrationSource(this, DatabaseHelper.getInstance(this, toName, toPath))
             val wordTables = MigrationTable.allTables(MigrationTables.values())
 
-            val progressDialog: ProgressDialog = ProgressDialog(this)
-            progressDialog.max = wordTables.count()
-            progressDialog.setTitle(getString(R.string.progress_import_title))
-            progressDialog.setMessage(getString(R.string.progress_import_message_y))
-            progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL)
-            progressDialog.setCancelable(false)
-            progressDialog.show()
+
+            val progressBar = ProgressBar(this, null, android.R.style.Widget_ProgressBar_Horizontal)
+            progressBar.max = wordTables.count()
+
+            val progressAlertDialog = alertDialog {
+                titleResource = R.string.progress_import_title
+                messageResource = R.string.progress_import_message_y
+                setCancelable(false)
+                setView(progressBar)
+            }
+            progressAlertDialog.show()
 
             MainScope().async {
                 wordTables.forEach {
                     val wordtable = migrationSource.getWordTable(it)
-                    progressDialog.incrementProgressBy(1)
+                    progressBar.incrementProgressBy(1)
                     wordtable.forEach {word ->
                         val source = WordSource(this@PrefsActivity)
                         if (word.counterTry > 0 || word.priority > 0)
@@ -248,7 +252,7 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 File(toPath + toName).delete()
 
                 withContext(Main) {
-                    progressDialog.dismiss()
+                    progressAlertDialog.dismiss()
                     alertDialog {
                         titleResource = R.string.restore_success
                         messageResource = R.string.restore_success_message

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
@@ -83,8 +83,4 @@ class AnswersActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    fun unlockFullVersion() {
-        answersFragment.unlockFullVersion()
-    }
-
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersActivity.kt
@@ -50,11 +50,11 @@ class AnswersActivity : AppCompatActivity() {
             setDisplayHomeAsUpEnabled(true)
         }
 
-        if (savedInstanceState != null) {
+        answersFragment = if (savedInstanceState != null) {
             //Restore the fragment's instance
-            answersFragment = supportFragmentManager.getFragment(savedInstanceState, "answersFragment") as AnswersFragment
+            supportFragmentManager.getFragment(savedInstanceState, "answersFragment") as AnswersFragment
         } else {
-            answersFragment = AnswersFragment()
+            AnswersFragment()
         }
         addOrReplaceFragment(R.id.container_content, answersFragment)
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersAdapter.kt
@@ -3,7 +3,6 @@ package com.jehutyno.yomikata.screens.answers
 import android.content.Context
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-//import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -33,13 +32,13 @@ class AnswersAdapter(private val context: Context, private val callback: Callbac
         val word = items[position].second
         val sentence = items[position].third
         holder.answer_image.setImageResource(getCategoryIcon(word.baseCategory))
-//        holder.answer_image.drawable?.setColorFilter(ContextCompat.getColor(context, R.color.answer_icon_color), PorterDuff.Mode.SRC_ATOP)
+
         val color = ContextCompat.getColor(context, R.color.answer_icon_color)
         holder.answer_image.drawable?.colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(color, BlendModeCompat.SRC_ATOP)
 
         holder.japanese.text_set(word.japanese, 0, word.japanese.length, getWordColor(context, word.level, word.points))
         holder.translation.text = word.getTrad()
-//        holder.answer.text = Html.fromHtml(answer.answer)
+
         holder.answer.text = HtmlCompat.fromHtml(answer.answer, HtmlCompat.FROM_HTML_MODE_LEGACY)
         holder.sentence_jap.text_set(
             sentence.jap,

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersAdapter.kt
@@ -62,6 +62,7 @@ class AnswersAdapter(private val context: Context, private val callback: Callbac
 
     fun replaceData(list: List<Triple<Answer, Word, Sentence>>) {
         items = list
+        @Suppress("notifyDataSetChanged")
         notifyDataSetChanged()
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersAdapter.kt
@@ -1,17 +1,18 @@
 package com.jehutyno.yomikata.screens.answers
 
 import android.content.Context
-import android.graphics.PorterDuff
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
-import android.text.Html
+//import android.text.Html
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
+import androidx.core.text.HtmlCompat
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.VhAnswerBinding
 import com.jehutyno.yomikata.model.*
-import com.jehutyno.yomikata.util.Prefs
 import com.jehutyno.yomikata.util.sentenceNoFuri
 
 /**
@@ -32,10 +33,14 @@ class AnswersAdapter(private val context: Context, private val callback: Callbac
         val word = items[position].second
         val sentence = items[position].third
         holder.answer_image.setImageResource(getCategoryIcon(word.baseCategory))
-        holder.answer_image.drawable?.setColorFilter(ContextCompat.getColor(context, R.color.answer_icon_color), PorterDuff.Mode.SRC_ATOP)
+//        holder.answer_image.drawable?.setColorFilter(ContextCompat.getColor(context, R.color.answer_icon_color), PorterDuff.Mode.SRC_ATOP)
+        val color = ContextCompat.getColor(context, R.color.answer_icon_color)
+        holder.answer_image.drawable?.colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(color, BlendModeCompat.SRC_ATOP)
+
         holder.japanese.text_set(word.japanese, 0, word.japanese.length, getWordColor(context, word.level, word.points))
         holder.translation.text = word.getTrad()
-        holder.answer.text = Html.fromHtml(answer.answer)
+//        holder.answer.text = Html.fromHtml(answer.answer)
+        holder.answer.text = HtmlCompat.fromHtml(answer.answer, HtmlCompat.FROM_HTML_MODE_LEGACY)
         holder.sentence_jap.text_set(
             sentence.jap,
             sentenceNoFuri(sentence).indexOf(word.japanese), sentenceNoFuri(sentence).indexOf(word.japanese) + word.japanese.length,

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -178,7 +178,4 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
         _binding = null
     }
 
-    fun unlockFullVersion() {
-        adapter.notifyDataSetChanged()
-    }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -11,17 +11,13 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.FrameLayout
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.KodeinInjector
-import com.github.salomonbrys.kodein.android.appKodein
-import com.github.salomonbrys.kodein.instance
-import com.github.salomonbrys.kodein.singleton
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.FragmentContentBinding
 import com.jehutyno.yomikata.managers.VoicesManager
 import com.jehutyno.yomikata.model.Answer
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.*
+import org.kodein.di.*
 import splitties.alertdialog.appcompat.alertDialog
 import splitties.alertdialog.appcompat.cancelButton
 import splitties.alertdialog.appcompat.okButton
@@ -33,11 +29,16 @@ import kotlin.collections.ArrayList
 /**
  * Created by valentin on 25/10/2016.
  */
-class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callback, TextToSpeech.OnInitListener {
+class AnswersFragment(private val di: DI) : Fragment(), AnswersContract.View, AnswersAdapter.Callback, TextToSpeech.OnInitListener {
 
-    private val injector = KodeinInjector()
+    // kodein
+    private val subDI by DI.lazy {
+        extend(di)
+        bind<VoicesManager>() with singleton { VoicesManager(requireActivity()) }
+    }
     @Suppress("unused")
-    private val voicesManager: VoicesManager by injector.instance()
+    private val voicesManager: VoicesManager by subDI.instance()
+
     private lateinit var presenter: AnswersContract.Presenter
     private lateinit var layoutManager: LinearLayoutManager
     private lateinit var adapter: AnswersAdapter
@@ -81,11 +82,6 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        injector.inject(Kodein {
-            extend(appKodein())
-            bind<VoicesManager>() with singleton { VoicesManager(requireActivity()) }
-        })
 
         binding.recyclerviewContent.let {
             it.adapter = adapter

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersFragment.kt
@@ -2,6 +2,7 @@ package com.jehutyno.yomikata.screens.answers
 
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.appcompat.widget.PopupMenu
@@ -26,6 +27,7 @@ import splitties.alertdialog.appcompat.cancelButton
 import splitties.alertdialog.appcompat.okButton
 import splitties.alertdialog.appcompat.titleResource
 import java.util.*
+import kotlin.collections.ArrayList
 
 
 /**
@@ -60,7 +62,13 @@ class AnswersFragment : Fragment(), AnswersContract.View, AnswersAdapter.Callbac
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         tts = TextToSpeech(activity, this)
-        val answers = LocalPersistence.readObjectFromFile(context, "answers") as ArrayList<Answer>
+
+        val answersListRaw = LocalPersistence.readObjectFromFile(context, "answers")
+        val answersList = answersListRaw as ArrayList<*>
+        val answers = answersListRaw.filterIsInstance<Answer>()
+        if (answers.size != answersList.size) {
+            Log.e("Failed cast", "Some items in the read list of answers were not of the type Answer")
+        }
         adapter = AnswersAdapter(requireActivity(), this)
         layoutManager = LinearLayoutManager(activity)
         adapter.replaceData(presenter.getAnswersWordsSentences(answers))

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersPresenterModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/answers/AnswersPresenterModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.screens.answers
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
 /**
  * Created by valentin on 25/10/2016.
  */
-fun answersPresenterModule(view: AnswersContract.View) = Kodein.Module {
+fun answersPresenterModule(view: AnswersContract.View) = DI.Module("answersPresenterModule") {
     bind<AnswersContract.View>() with instance(view)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
@@ -239,8 +239,4 @@ class ContentActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    fun unlockFullVersion() {
-        finish()
-    }
-
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
@@ -128,7 +128,7 @@ class ContentActivity : AppCompatActivity(), DIAware {
                     trigger.trigger()
 
                 } else {
-                    contentPagerAdapter = ContentPagerAdapter(this@ContentActivity, supportFragmentManager, quizzes, lifecycle, di)
+                    contentPagerAdapter = ContentPagerAdapter(this@ContentActivity, quizzes, di)
                     binding.pagerContent.adapter = contentPagerAdapter
                     val quizTitle = quizzes[quizPosition].getName().split("%")[0]
                     quizIds = longArrayOf(quizzes[quizPosition].id)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
@@ -175,18 +175,28 @@ class ContentActivity : AppCompatActivity() {
             }
         }
 
+        /**
+         * Collapse or quit
+         * If action button is expanded -> collapse it
+         * Otherwise -> finish this activity
+         */
+        fun collapseOrQuit() {
+            if (binding.multipleActions.isExpanded)
+                binding.multipleActions.collapse()
+            else
+                finish()
+        }
+
         // set back button to close floating actions menu
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             onBackInvokedDispatcher.registerOnBackInvokedCallback(
                     OnBackInvokedDispatcher.PRIORITY_DEFAULT
             ) {
-                if (binding.multipleActions.isExpanded)
-                    binding.multipleActions.collapse()
+                collapseOrQuit()
             }
         } else {
             onBackPressedDispatcher.addCallback(this) {
-                if (binding.multipleActions.isExpanded)
-                    binding.multipleActions.collapse()
+                collapseOrQuit()
             }
         }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
-import androidx.viewpager.widget.ViewPager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import android.view.MenuItem
@@ -14,6 +13,7 @@ import android.view.View.VISIBLE
 import android.window.OnBackInvokedDispatcher
 import androidx.activity.addCallback
 import androidx.preference.PreferenceManager
+import androidx.viewpager2.widget.ViewPager2
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
 import com.github.salomonbrys.kodein.android.appKodein
@@ -127,20 +127,13 @@ class ContentActivity : AppCompatActivity() {
                         }
                     })
                 } else {
-                    contentPagerAdapter = ContentPagerAdapter(this@ContentActivity, supportFragmentManager, quizzes)
+                    contentPagerAdapter = ContentPagerAdapter(this@ContentActivity, supportFragmentManager, quizzes, lifecycle)
                     binding.pagerContent.adapter = contentPagerAdapter
                     val quizTitle = quizzes[quizPosition].getName().split("%")[0]
                     quizIds = longArrayOf(quizzes[quizPosition].id)
                     title = quizTitle
                     binding.pagerContent.currentItem = quizPosition
-                    binding.pagerContent.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
-                        override fun onPageScrollStateChanged(state: Int) {
-
-                        }
-
-                        override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
-
-                        }
+                    binding.pagerContent.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
 
                         override fun onPageSelected(position: Int) {
                             val newQuizTitle = quizzes[position].getName().split("%")[0]

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentActivity.kt
@@ -3,6 +3,7 @@ package com.jehutyno.yomikata.screens.content
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import androidx.viewpager.widget.ViewPager
 import androidx.appcompat.app.AppCompatActivity
@@ -10,6 +11,8 @@ import androidx.appcompat.app.AppCompatDelegate
 import android.view.MenuItem
 import android.view.View.GONE
 import android.view.View.VISIBLE
+import android.window.OnBackInvokedDispatcher
+import androidx.activity.addCallback
 import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
@@ -178,6 +181,22 @@ class ContentActivity : AppCompatActivity() {
                 else -> launchQuiz(QuizStrategy.SHUFFLE)
             }
         }
+
+        // set back button to close floating actions menu
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            onBackInvokedDispatcher.registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_DEFAULT
+            ) {
+                if (binding.multipleActions.isExpanded)
+                    binding.multipleActions.collapse()
+            }
+        } else {
+            onBackPressedDispatcher.addCallback(this) {
+                if (binding.multipleActions.isExpanded)
+                    binding.multipleActions.collapse()
+            }
+        }
+
     }
 
     private fun launchQuiz(strategy: QuizStrategy) {
@@ -215,13 +234,6 @@ class ContentActivity : AppCompatActivity() {
             }
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        if (binding.multipleActions.isExpanded)
-            binding.multipleActions.collapse()
-        else
-            super.onBackPressed()
     }
 
     fun unlockFullVersion() {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
@@ -11,8 +11,6 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.widget.EditText
 import android.widget.FrameLayout
-import com.github.salomonbrys.kodein.android.appKodein
-import com.github.salomonbrys.kodein.instance
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.FragmentContentGraphBinding
 import com.jehutyno.yomikata.model.Quiz
@@ -21,6 +19,7 @@ import com.jehutyno.yomikata.screens.content.word.WordDetailDialogFragment
 import com.jehutyno.yomikata.util.DimensionHelper
 import com.jehutyno.yomikata.util.Extras
 import com.jehutyno.yomikata.util.SeekBarsManager
+import org.kodein.di.*
 import splitties.alertdialog.appcompat.*
 import java.util.*
 
@@ -28,7 +27,8 @@ import java.util.*
 /**
  * Created by valentin on 30/09/2016.
  */
-class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback, DialogInterface.OnDismissListener {
+class ContentFragment(private val di: DI) : Fragment(), ContentContract.View, WordsAdapter.Callback, DialogInterface.OnDismissListener {
+
     private var mpresenter: ContentContract.Presenter? = null
     private lateinit var adapter: WordsAdapter
     private lateinit var quizIds: LongArray
@@ -134,8 +134,9 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        if (mpresenter == null)
-            mpresenter = ContentPresenter(requireContext().appKodein.invoke().instance(), requireContext().appKodein.invoke().instance(), this)
+        if (mpresenter == null) {
+            mpresenter = ContentPresenter(di.direct.instance(), di.direct.instance(), this@ContentFragment)
+        }
 
         binding.recyclerviewContent.let {
             it.adapter = adapter
@@ -159,7 +160,7 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
         bundle.putInt(Extras.EXTRA_WORD_POSITION, position)
         bundle.putString(Extras.EXTRA_SEARCH_STRING, "")
 
-        val dialog = WordDetailDialogFragment()
+        val dialog = WordDetailDialogFragment(di)
         dialog.arguments = bundle
         dialog.show(childFragmentManager, "")
         dialog.isCancelable = true

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
@@ -325,8 +325,4 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
         _binding = null
     }
 
-    fun unlockFullVersion() {
-        adapter.notifyDataSetChanged()
-    }
-
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentFragment.kt
@@ -171,22 +171,19 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
     private val actionModeCallback = object : ActionMode.Callback {
         override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
             adapter.checkMode = true
-            adapter.notifyDataSetChanged()
+            adapter.notifyItemRangeChanged(0, adapter.items.size)
             return false
         }
 
+        private val ADD_TO_SELECTIONS = 1
+        private val REMOVE_FROM_SELECTIONS = 2
+        private val SELECT_ALL = 3
+        private val UNSELECT_ALL = 4
+
         override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
             when (item.itemId) {
-                3 -> {
-                    adapter.items.forEach { it.isSelected = 1 }
-                    adapter.notifyDataSetChanged()
-                }
-                4 -> {
-                    adapter.items.forEach { it.isSelected = 0 }
-                    adapter.notifyDataSetChanged()
-                }
-                1 -> {
-                    val popup = PopupMenu(activity!!, activity!!.findViewById(1))
+                ADD_TO_SELECTIONS -> {
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(item.itemId))
                     popup.menuInflater.inflate(R.menu.popup_selections, popup.menu)
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
@@ -209,8 +206,8 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
                     }
                     popup.show()
                 }
-                2 -> {
-                    val popup = PopupMenu(activity!!, activity!!.findViewById(2))
+                REMOVE_FROM_SELECTIONS -> {
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(item.itemId))
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
                     }
@@ -231,6 +228,14 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
                     }
                     popup.show()
 
+                }
+                SELECT_ALL -> {
+                    adapter.items.forEach { it.isSelected = 1 }
+                    adapter.notifyItemRangeChanged(0, adapter.items.size)
+                }
+                UNSELECT_ALL -> {
+                    adapter.items.forEach { it.isSelected = 0 }
+                    adapter.notifyItemRangeChanged(0, adapter.items.size)
                 }
             }
             return false
@@ -263,23 +268,22 @@ class ContentFragment : Fragment(), ContentContract.View, WordsAdapter.Callback,
             }.show()
         }
 
-
         override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
             mode.title = null
-            menu.add(0, 1, 0, getString(R.string.add_to_selections)).setIcon(R.drawable.ic_selections_selected)
+            menu.add(0, ADD_TO_SELECTIONS, 0, getString(R.string.add_to_selections)).setIcon(R.drawable.ic_selections_selected)
                     .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            menu.add(0, 2, 0, getString(R.string.remove_from_selection)).setIcon(R.drawable.ic_unselect)
+            menu.add(0, REMOVE_FROM_SELECTIONS, 0, getString(R.string.remove_from_selection)).setIcon(R.drawable.ic_unselect)
                     .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            menu.add(0, 3, 0, getString(R.string.select_all)).setIcon(R.drawable.ic_select_multiple)
+            menu.add(0, SELECT_ALL, 0, getString(R.string.select_all)).setIcon(R.drawable.ic_select_multiple)
                     .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            menu.add(0, 4, 0, getString(R.string.unselect_all)).setIcon(R.drawable.ic_unselect_multiple)
+            menu.add(0, UNSELECT_ALL, 0, getString(R.string.unselect_all)).setIcon(R.drawable.ic_unselect_multiple)
                     .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
             return true
         }
 
         override fun onDestroyActionMode(mode: ActionMode?) {
             adapter.checkMode = false
-            adapter.notifyDataSetChanged()
+            adapter.notifyItemRangeChanged(0, adapter.items.size)
         }
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
-import androidx.viewpager.widget.PagerAdapter
+import androidx.lifecycle.Lifecycle
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.Extras
 
@@ -13,23 +13,24 @@ import com.jehutyno.yomikata.util.Extras
 /**
  * Created by valentin on 19/12/2016.
  */
-class ContentPagerAdapter(val context : Context, fm: FragmentManager, var quizzes: List<Quiz>) : FragmentStatePagerAdapter(fm) {
+class ContentPagerAdapter(val context : Context, fm: FragmentManager, var quizzes: List<Quiz>,
+                          lifecycle: Lifecycle) : FragmentStateAdapter (fm, lifecycle) {
 
-    override fun getItem(position: Int): Fragment {
+//    override fun getItemPosition(`object`: Any): Int {
+//        return PagerAdapter.POSITION_NONE
+//    }
+
+    override fun getItemCount(): Int {
+        return quizzes.size
+    }
+
+    override fun createFragment(position: Int): Fragment {
         val bundle = Bundle()
         bundle.putLongArray(Extras.EXTRA_QUIZ_IDS, longArrayOf(quizzes[position].id))
         bundle.putString(Extras.EXTRA_QUIZ_TITLE, quizzes[position].getName())
         val contentFragment = ContentFragment()
         contentFragment.arguments = bundle
         return contentFragment
-    }
-
-    override fun getCount(): Int {
-        return quizzes.size
-    }
-
-    override fun getItemPosition(`object`: Any): Int {
-        return PagerAdapter.POSITION_NONE
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
@@ -8,13 +8,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.Extras
+import org.kodein.di.DI
 
 
 /**
  * Created by valentin on 19/12/2016.
  */
 class ContentPagerAdapter(val context : Context, fm: FragmentManager, var quizzes: List<Quiz>,
-                          lifecycle: Lifecycle) : FragmentStateAdapter (fm, lifecycle) {
+                          lifecycle: Lifecycle, private val di: DI) : FragmentStateAdapter (fm, lifecycle) {
 
 //    override fun getItemPosition(`object`: Any): Int {
 //        return PagerAdapter.POSITION_NONE
@@ -28,7 +29,7 @@ class ContentPagerAdapter(val context : Context, fm: FragmentManager, var quizze
         val bundle = Bundle()
         bundle.putLongArray(Extras.EXTRA_QUIZ_IDS, longArrayOf(quizzes[position].id))
         bundle.putString(Extras.EXTRA_QUIZ_TITLE, quizzes[position].getName())
-        val contentFragment = ContentFragment()
+        val contentFragment = ContentFragment(di)
         contentFragment.arguments = bundle
         return contentFragment
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPagerAdapter.kt
@@ -1,10 +1,7 @@
 package com.jehutyno.yomikata.screens.content
 
-import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.jehutyno.yomikata.model.Quiz
 import com.jehutyno.yomikata.util.Extras
@@ -14,8 +11,7 @@ import org.kodein.di.DI
 /**
  * Created by valentin on 19/12/2016.
  */
-class ContentPagerAdapter(val context : Context, fm: FragmentManager, var quizzes: List<Quiz>,
-                          lifecycle: Lifecycle, private val di: DI) : FragmentStateAdapter (fm, lifecycle) {
+class ContentPagerAdapter(activity: ContentActivity, var quizzes: List<Quiz>, private val di: DI) : FragmentStateAdapter(activity) {
 
 //    override fun getItemPosition(`object`: Any): Int {
 //        return PagerAdapter.POSITION_NONE

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPresenterModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/ContentPresenterModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.screens.content
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
 /**
  * Created by valentin on 29/09/2016.
  */
-fun contentPresenterModule(view: ContentContract.View) = Kodein.Module {
+fun contentPresenterModule(view: ContentContract.View) = DI.Module("contentPresenterModule") {
     bind<ContentContract.View>() with instance(view)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
@@ -1,13 +1,14 @@
 package com.jehutyno.yomikata.screens.content
 
 import android.content.Context
-import android.graphics.PorterDuff
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
+import androidx.core.graphics.BlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.VhWordShortBinding
 import com.jehutyno.yomikata.model.Word
@@ -36,7 +37,10 @@ class WordsAdapter(private val context: Context, private val callback: Callback)
         holder.wordName.text = word.japanese
         holder.wordName.setTextColor(getWordColor(context, word.level, word.points))
         holder.categoryIcon.setImageResource(getCategoryIcon(word.baseCategory))
-        holder.categoryIcon.drawable?.setColorFilter(ContextCompat.getColor(context, R.color.content_icon_color), PorterDuff.Mode.SRC_ATOP)
+
+        val color = ContextCompat.getColor(context, R.color.content_icon_color)
+        holder.categoryIcon.drawable?.colorFilter = BlendModeColorFilterCompat.createBlendModeColorFilterCompat(color, BlendModeCompat.SRC_ATOP)
+
         flag = true
         holder.checkBox.isChecked = word.isSelected == 1
         flag = false

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/WordsAdapter.kt
@@ -61,7 +61,7 @@ class WordsAdapter(private val context: Context, private val callback: Callback)
             setOnClickListener {
                 checkMode = true
                 word.isSelected = 1
-                notifyDataSetChanged()
+                notifyItemRangeChanged(0, items.size)
                 callback.onCategoryIconClick(position)
             }
         }
@@ -86,6 +86,7 @@ class WordsAdapter(private val context: Context, private val callback: Callback)
     fun replaceData(list: List<Word>) {
         items.clear()
         items.addAll(list)
+        @Suppress("notifyDataSetChanged")
         notifyDataSetChanged()
     }
 
@@ -102,8 +103,9 @@ class WordsAdapter(private val context: Context, private val callback: Callback)
     }
 
     fun clearData() {
+        val size = items.size
         items.clear()
-        notifyDataSetChanged()
+        notifyItemRangeRemoved(0, size)
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordContract.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordContract.kt
@@ -27,7 +27,7 @@ interface WordContract {
         fun isWordInQuizzes(wordId: Long, quizIds: Array<Long>) : ArrayList<Boolean>
         fun isWordInQuiz(wordId: Long, quizId: Long) : Boolean
         fun deleteWordFromSelection(wordId: Long, selectionId: Long)
-        fun searchWords(seazrchString: String)
+        fun searchWords(searchString: String)
         fun levelUp(id: Long, level: Int) : Int
         fun levelDown(id: Long, level: Int) : Int
         fun loadWord(wordId: Long)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordDetailDialogFragment.kt
@@ -2,6 +2,7 @@ package com.jehutyno.yomikata.screens.content.word
 
 import android.app.Dialog
 import android.content.DialogInterface
+import android.os.Build
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.view.View
@@ -79,7 +80,15 @@ class WordDetailDialogFragment : DialogFragment(), WordContract.View, WordPagerA
         tts = TextToSpeech(activity, this)
         if (arguments != null) {
             wordId = requireArguments().getLong(Extras.EXTRA_WORD_ID, -1L)
-            quizType = requireArguments().getSerializable(Extras.EXTRA_QUIZ_TYPE) as QuizType?
+
+            quizType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                requireArguments().getSerializable(Extras.EXTRA_QUIZ_TYPE, QuizType::class.java)
+            }
+            else {
+                @Suppress("DEPRECATION")
+                requireArguments().getSerializable(Extras.EXTRA_QUIZ_TYPE) as QuizType?
+            }
+
             quizIds = requireArguments().getLongArray(Extras.EXTRA_QUIZ_IDS)
             quizTitle = requireArguments().getString(Extras.EXTRA_QUIZ_TITLE)
             wordPosition = requireArguments().getInt(Extras.EXTRA_WORD_POSITION)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordPagerAdapter.kt
@@ -45,7 +45,7 @@ class WordPagerAdapter(val activity: Activity, var quizType: QuizType?, var call
         binding.levelUp.visibility = if (quizType != null) GONE else VISIBLE
         wordDisplay.let { binding.furiWord.text_set(wordDisplay, 0, it.length, getWordColor(container.context, word.first.level, word.first.points)) }
         binding.textTraduction.text = word.first.getTrad()
-        val sentenceNoFuri = sentenceNoFuri(word.third)
+//        val sentenceNoFuri = sentenceNoFuri(word.third)
         val wordTruePosition = word.third.jap.let { getWordPositionInFuriSentence(it, word.first) }
         wordTruePosition.let {
             binding.furiSentence.text_set(

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordPresenter.kt
@@ -77,8 +77,8 @@ class WordPresenter(
         contentView.displayWords(wordsRad)
     }
 
-    override fun searchWords(seazrchString: String) {
-        wordRepository.searchWords(seazrchString, object : WordRepository.LoadWordsCallback {
+    override fun searchWords(searchString: String) {
+        wordRepository.searchWords(searchString, object : WordRepository.LoadWordsCallback {
             override fun onWordsLoaded(words: List<Word>) {
                 val wordsRad = mutableListOf<Triple<Word, List<KanjiSoloRadical?>, Sentence>>()
                 words.forEach {
@@ -89,7 +89,7 @@ class WordPresenter(
             }
 
             override fun onDataNotAvailable() {
-                logger.info { "*************** NO DATA FOUND FOR QUIZ : $seazrchString ***************" }
+                logger.info { "*************** NO DATA FOUND FOR QUIZ : $searchString ***************" }
             }
 
         })
@@ -138,25 +138,25 @@ class WordPresenter(
     }
 
     override fun levelUp(id: Long, level: Int): Int {
-        if (level < 3) {
+        return if (level < 3) {
             wordRepository.updateWordLevel(id, level + 1)
-            return level + 1
+            level + 1
         } else if (level == 3) {
             wordRepository.updateWordPoints(id, 100)
-            return 3
+            3
         } else {
-            return level
+            level
         }
     }
 
     override fun levelDown(id: Long, level: Int): Int {
-        if (level > 0) {
+        return if (level > 0) {
             wordRepository.updateWordPoints(id, 0)
             wordRepository.updateWordLevel(id, level - 1)
-            return level - 1
+            level - 1
         } else {
             wordRepository.updateWordPoints(id, 0)
-            return level
+            level
         }
     }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordPresenterModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/content/word/WordPresenterModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.screens.content.word
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
 /**
  * Created by valentin on 29/09/2016.
  */
-fun wordPresenterModule(view: WordContract.View) = Kodein.Module {
+fun wordPresenterModule(view: WordContract.View) = DI.Module("wordPresenterModule") {
     bind<WordContract.View>() with instance(view)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -119,7 +119,7 @@ class HomeFragment : Fragment(), HomeContract.View {
         textViews[3].text = getString(R.string.wrong_answers, wrongAnswer)
     }
 
-    fun displayLatestCategories() {
+    private fun displayLatestCategories() {
         val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         val cat1 = pref.getInt(Prefs.LATEST_CATEGORY_1.pref, -1)
         val cat2 = pref.getInt(Prefs.LATEST_CATEGORY_2.pref, -1)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -46,10 +46,6 @@ class HomeFragment : Fragment(), HomeContract.View {
         mpresenter = presenter
     }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
-
     override fun onResume() {
         super.onResume()
         mpresenter!!.start()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -46,6 +46,14 @@ class HomeFragment : Fragment(), HomeContract.View {
         mpresenter = presenter
     }
 
+    override fun onStart() {
+        // preload for viewPager2
+        super.onStart()
+        mpresenter!!.start()
+        mpresenter!!.loadAllStats()
+        displayLatestCategories()
+    }
+
     override fun onResume() {
         super.onResume()
         mpresenter!!.start()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -9,8 +9,6 @@ import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.preference.PreferenceManager
-import com.github.salomonbrys.kodein.android.appKodein
-import com.github.salomonbrys.kodein.instance
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.FirebaseDatabase
@@ -22,6 +20,7 @@ import com.jehutyno.yomikata.model.StatEntry
 import com.jehutyno.yomikata.model.StatResult
 import com.jehutyno.yomikata.screens.quizzes.QuizzesActivity
 import com.jehutyno.yomikata.util.*
+import org.kodein.di.*
 
 import java.util.*
 
@@ -29,9 +28,12 @@ import java.util.*
 /**
  * Created by valentin on 26/12/2016.
  */
-class HomeFragment : Fragment(), HomeContract.View {
+class HomeFragment(di: DI) : Fragment(), HomeContract.View {
 
-    private var mpresenter: HomeContract.Presenter? = null
+    // kodein
+    private val mpresenter: HomeContract.Presenter by di.newInstance {
+        HomePresenter(instance(), instance(), this@HomeFragment)
+    }
 
     // View Binding
     private var _binding: FragmentHomeBinding? = null
@@ -43,21 +45,22 @@ class HomeFragment : Fragment(), HomeContract.View {
     }
 
     override fun setPresenter(presenter: HomeContract.Presenter) {
-        mpresenter = presenter
+        // no need: see QuizzesFragment setPresenter for explanation
+//        mpresenter = presenter
     }
 
     override fun onStart() {
         // preload for viewPager2
         super.onStart()
-        mpresenter!!.start()
-        mpresenter!!.loadAllStats()
+        mpresenter.start()
+        mpresenter.loadAllStats()
         displayLatestCategories()
     }
 
     override fun onResume() {
         super.onResume()
-        mpresenter!!.start()
-        mpresenter!!.loadAllStats()
+        mpresenter.start()
+        mpresenter.loadAllStats()
         displayLatestCategories()
     }
 
@@ -68,10 +71,6 @@ class HomeFragment : Fragment(), HomeContract.View {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        if (mpresenter == null) {
-            mpresenter = HomePresenter(requireActivity().appKodein.invoke().instance(), requireContext().appKodein.invoke().instance(), this)
-        }
 
         val database = FirebaseDatabase.getInstance()
         val newsRef = if (Locale.getDefault().language == "fr")

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -107,11 +107,11 @@ class HomeFragment : Fragment(), HomeContract.View {
         displayStat(stats, binding.totalQuizLaunch, binding.totalWordsSeen, binding.totalGoodAnswer, binding.totalWrongAnswer)
     }
 
-    fun displayStat(stats: List<StatEntry>, vararg textViews: TextView) {
-        val quizLaunched = stats.filter { it.action == StatAction.LAUNCH_QUIZ_FROM_CATEGORY.value }.count()
-        val wordsSeen = stats.filter { it.action == StatAction.WORD_SEEN.value }.count()
-        val goodAnswer = stats.filter { it.action == StatAction.ANSWER_QUESTION.value && it.result == StatResult.SUCCESS.value }.count()
-        val wrongAnswer = stats.filter { it.action == StatAction.ANSWER_QUESTION.value && it.result == StatResult.FAIL.value }.count()
+    private fun displayStat(stats: List<StatEntry>, vararg textViews: TextView) {
+        val quizLaunched = stats.count { it.action == StatAction.LAUNCH_QUIZ_FROM_CATEGORY.value }
+        val wordsSeen = stats.count { it.action == StatAction.WORD_SEEN.value }
+        val goodAnswer = stats.count { it.action == StatAction.ANSWER_QUESTION.value && it.result == StatResult.SUCCESS.value }
+        val wrongAnswer = stats.count { it.action == StatAction.ANSWER_QUESTION.value && it.result == StatResult.FAIL.value }
 
         textViews[0].text = getString(R.string.quiz_launched, quizLaunched)
         textViews[1].text = getString(R.string.words_seen, wordsSeen)
@@ -146,7 +146,7 @@ class HomeFragment : Fragment(), HomeContract.View {
         binding.noCategories.visibility = if (cat1 == -1 && cat2 == -1) VISIBLE else GONE
     }
 
-    fun getCategoryResId(category: Int): Int {
+    private fun getCategoryResId(category: Int): Int {
         return when (category) {
             Categories.CATEGORY_HIRAGANA -> {
                 R.drawable.ic_hiragana_big

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -120,7 +120,7 @@ class HomeFragment : Fragment(), HomeContract.View {
     }
 
     fun displayLatestCategories() {
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         val cat1 = pref.getInt(Prefs.LATEST_CATEGORY_1.pref, -1)
         val cat2 = pref.getInt(Prefs.LATEST_CATEGORY_2.pref, -1)
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/home/HomeFragment.kt
@@ -62,7 +62,7 @@ class HomeFragment : Fragment(), HomeContract.View {
         super.onViewCreated(view, savedInstanceState)
 
         if (mpresenter == null) {
-            mpresenter = HomePresenter(activity!!.appKodein.invoke().instance(), context!!.appKodein.invoke().instance(), this)
+            mpresenter = HomePresenter(requireActivity().appKodein.invoke().instance(), requireContext().appKodein.invoke().instance(), this)
         }
 
         val database = FirebaseDatabase.getInstance()
@@ -84,10 +84,10 @@ class HomeFragment : Fragment(), HomeContract.View {
             }
         })
 
-        binding.share.setOnClickListener { shareApp(activity!!) }
+        binding.share.setOnClickListener { shareApp(requireActivity()) }
         binding.facebook.setOnClickListener { contactFacebook(activity) }
-        binding.playStore.setOnClickListener { contactPlayStore(activity!!) }
-        binding.discord.setOnClickListener { contactDiscord(activity!!) }
+        binding.playStore.setOnClickListener { contactPlayStore(requireActivity()) }
+        binding.discord.setOnClickListener { contactDiscord(requireActivity()) }
 
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
@@ -65,11 +65,27 @@ class QuizActivity : AppCompatActivity() {
             //Restore the fragment's instance
             quizFragment = supportFragmentManager.getFragment(savedInstanceState, "quizFragment") as QuizFragment
             quizIds = savedInstanceState.getLongArray("quiz_ids")?: longArrayOf()
-            quizStrategy = savedInstanceState.getSerializable("quiz_strategy") as QuizStrategy
+
+            quizStrategy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                savedInstanceState.getSerializable("quiz_strategy", QuizStrategy::class.java)!!
+            }
+            else {
+                @Suppress("DEPRECATION")
+                savedInstanceState.getSerializable("quiz_strategy") as QuizStrategy
+            }
+
             quizTypes = savedInstanceState.getIntArray("quiz_types")?: intArrayOf()
         } else {
             quizIds = intent.getLongArrayExtra(Extras.EXTRA_QUIZ_IDS) ?: longArrayOf()
-            quizStrategy = intent.getSerializableExtra(Extras.EXTRA_QUIZ_STRATEGY) as QuizStrategy
+
+            quizStrategy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                intent.getSerializableExtra(Extras.EXTRA_QUIZ_STRATEGY, QuizStrategy::class.java)!!
+            }
+            else {
+                @Suppress("DEPRECATION")
+                intent.getSerializableExtra(Extras.EXTRA_QUIZ_STRATEGY) as QuizStrategy
+            }
+
             quizTypes = intent.getIntArrayExtra(Extras.EXTRA_QUIZ_TYPES) ?: intArrayOf()
 
             val bundle = Bundle()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
@@ -2,11 +2,14 @@ package com.jehutyno.yomikata.screens.quiz
 
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import android.view.KeyEvent
 import android.view.MenuItem
+import android.window.OnBackInvokedDispatcher
+import androidx.activity.addCallback
 import androidx.preference.PreferenceManager
 import com.github.salomonbrys.kodein.Kodein
 import com.github.salomonbrys.kodein.KodeinInjector
@@ -86,6 +89,32 @@ class QuizActivity : AppCompatActivity() {
                 QuizPresenter(instance(), instance(), instance(), instance(), instance(), instance(), quizIds, quizStrategy, quizTypes)
             }
         })
+
+        fun askToQuitSession() {
+            alertDialog(getString(R.string.quit_quiz)) {
+                okButton { finish() }
+                cancelButton()
+                setOnKeyListener { _, keyCode, _ ->
+                    if (keyCode == KeyEvent.KEYCODE_BACK)
+                        finish()
+                    true
+                }
+            }.show()
+        }
+
+        // set back button: ask if user wants to quit out of session
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            onBackInvokedDispatcher.registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_DEFAULT
+            ) {
+                askToQuitSession()
+            }
+        } else {
+            onBackPressedDispatcher.addCallback(this /* lifecycle owner */) {
+                askToQuitSession()
+            }
+        }
+
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -110,18 +139,6 @@ class QuizActivity : AppCompatActivity() {
             }
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        alertDialog(getString(R.string.quit_quiz)) {
-            okButton { finish() }
-            cancelButton()
-            setOnKeyListener { _, keyCode, _ ->
-                if (keyCode == KeyEvent.KEYCODE_BACK)
-                    finish()
-                true
-            }
-        }.show()
     }
 
     fun unlockFullVersion() {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizActivity.kt
@@ -157,7 +157,4 @@ class QuizActivity : AppCompatActivity() {
         return super.onOptionsItemSelected(item)
     }
 
-    fun unlockFullVersion() {
-        quizFragment.unlockFullVersion()
-    }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -596,7 +596,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
 
     override fun showKeyboard() {
         val inputMethodManager = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        inputMethodManager.showSoftInput(binding.hiraganaEdit, InputMethodManager.SHOW_FORCED)
+        inputMethodManager.showSoftInput(binding.hiraganaEdit, InputMethodManager.SHOW_IMPLICIT)
         binding.hiraganaEdit.requestFocus()
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -180,10 +180,9 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
             ttsErrorsImage.setPadding(pad, pad, pad, pad)
             ttsErrorsImage.setOnClickListener {
                 val category = adapter!!.words[binding.pager.currentItem].first.baseCategory
-                val speechAvailability = checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(category))
-                when (speechAvailability) {
+                when (val speechAvailability = checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(category))) {
                     SpeechAvailability.NOT_AVAILABLE -> {
-                        speechNotSupportedAlert(requireActivity(), getCategoryLevel(category), {})
+                        speechNotSupportedAlert(requireActivity(), getCategoryLevel(category)) {}
                     }
                     else -> {
                         if (isSettingsOpen) {
@@ -257,7 +256,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
 
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
                 if (isSettingsOpen) closeTTSSettings()
-                // Return to nuraml color when typing again (because it becomes Red or Green when
+                // Return to normal color when typing again (because it becomes Red or Green when
                 // you validate
                 currentEditColor = R.color.lighter_gray
                 binding.hiraganaEdit.setTextColor(ContextCompat.getColor(activity!!, currentEditColor))
@@ -333,7 +332,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
         }
     }
 
-    fun initAnswersButtons() {
+    private fun initAnswersButtons() {
         binding.quizContainer.setOnClickListener { if (isSettingsOpen) closeTTSSettings() }
         binding.answerContainer.setOnClickListener { if (isSettingsOpen) closeTTSSettings() }
         binding.option1Container.setOnClickListener {
@@ -608,9 +607,9 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
 
     override fun animateColor(position: Int, word: Word, sentence: Sentence, quizType: QuizType, fromLevel: Int, toLevel: Int, fromPoints: Int, toPoints: Int) {
         val view = binding.pager.findViewWithTag<View>("pos_$position")
-        val btn_furi = view.findViewById<View>(R.id.btn_furi)
-        val furi_sentence = view.findViewById<FuriganaView>(R.id.furi_sentence)
-        val trad_sentence = view.findViewById<TextView>(R.id.trad_sentence)
+        val btnFuri = view.findViewById<View>(R.id.btn_furi)
+        val furiSentence = view.findViewById<FuriganaView>(R.id.furi_sentence)
+        val tradSentence = view.findViewById<TextView>(R.id.trad_sentence)
         val sound = view.findViewById<ImageButton>(R.id.sound)
         val sentenceNoFuri = sentenceNoFuri(sentence)
         val colorAnimation = ValueAnimator.ofObject(ArgbEvaluator(),
@@ -623,16 +622,15 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
                     QuizType.TYPE_PRONUNCIATION, QuizType.TYPE_PRONUNCIATION_QCM, QuizType.TYPE_JAP_EN -> {
                         val colorEntireWord = word.isKana == 2 && quizType == QuizType.TYPE_JAP_EN
                         val wordTruePosition = if (colorEntireWord) 0 else getWordPositionInFuriSentence(sentence.jap, word)
-                        if (btn_furi.isSelected) {
+                        if (btnFuri.isSelected) {
                             if (!colorEntireWord) wordTruePosition.let {
-                                furi_sentence.text_set(
-                                    if (colorEntireWord) sentence.jap else sentenceNoAnswerFuri(sentence, word),
-                                    it,
-                                    if (colorEntireWord) sentence.jap.length else wordTruePosition + word.japanese.length,
+                                furiSentence.text_set(
+                                    sentenceNoAnswerFuri(sentence, word), it,
+                             wordTruePosition + word.japanese.length,
                                     animator.animatedValue as Int)
                             }
                         } else {
-                            furi_sentence.text_set(
+                            furiSentence.text_set(
                                 if (colorEntireWord) sentence.jap else sentenceNoFuri.replace("%", word.japanese),
                                 (if (colorEntireWord) 0 else wordTruePosition),
                                 if (colorEntireWord) sentence.jap.length else wordTruePosition + word.japanese.length,
@@ -640,7 +638,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
                         }
                     }
                     QuizType.TYPE_EN_JAP -> {
-                        trad_sentence.setTextColor(animator.animatedValue as Int)
+                        tradSentence.setTextColor(animator.animatedValue as Int)
                     }
                     QuizType.TYPE_AUDIO -> {
                         sound.setColorFilter(animator.animatedValue as Int)
@@ -763,10 +761,9 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
             }
             R.id.tts_settings -> {
                 val category = adapter!!.words[binding.pager.currentItem].first.baseCategory
-                val speechAvailability = checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(category))
-                when (speechAvailability) {
+                when (val speechAvailability = checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(category))) {
                     SpeechAvailability.NOT_AVAILABLE -> {
-                        speechNotSupportedAlert(requireActivity(), getCategoryLevel(category), {})
+                        speechNotSupportedAlert(requireActivity(), getCategoryLevel(category)) {}
                     }
                     else -> {
                         if (isSettingsOpen) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -68,7 +68,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
         if (adapter != null && adapter!!.words.isNotEmpty()) {
             ttsSupported = onTTSinit(activity, status, tts)
             presenter.setTTSSupported(ttsSupported)
-            val pref = PreferenceManager.getDefaultSharedPreferences(context)
+            val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
             val noPlayStart = pref.getBoolean("play_start", false)
             if (adapter!!.words[binding.pager.currentItem].second == QuizType.TYPE_AUDIO || noPlayStart) {
                 voicesManager.speakWord(adapter!!.words[binding.pager.currentItem].first, ttsSupported, tts)
@@ -100,7 +100,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
 
     override fun onResume() {
         super.onResume()
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         binding.hiraganaEdit.inputType = if (pref.getBoolean("input_change", false))
             InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
         else
@@ -308,7 +308,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
         })
 
         binding.seekSpeed.max = 250
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         val rate = pref.getInt(Prefs.TTS_RATE.pref, 50)
         binding.seekSpeed.progress = rate
         tts?.setSpeechRate((rate + 50).toFloat() / 100)
@@ -518,7 +518,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
     }
 
     override fun displayQCMNormalTextViews() {
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         binding.option1Tv.textSize = pref.getString("font_size", "18")!!.toFloat()
         binding.option2Tv.textSize = pref.getString("font_size", "18")!!.toFloat()
         binding.option3Tv.textSize = pref.getString("font_size", "18")!!.toFloat()
@@ -685,7 +685,7 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
     }
 
     override fun showAlertNonProgressiveSessionEnd(proposeErrors: Boolean) {
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
 
         requireContext().alertDialog {
             message = getString(R.string.alert_session_finished, pref.getString("length", "-1")?.toInt())

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -849,10 +849,6 @@ class QuizFragment : Fragment(), QuizContract.View, QuizItemPagerAdapter.Callbac
 
     }
 
-    fun unlockFullVersion() {
-        adapter!!.notifyDataSetChanged()
-    }
-
     private fun addSelection(wordId: Long) {
         val input = EditText(activity)
         input.setSingleLine()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -787,7 +787,7 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
 
     override fun onItemClick(position: Int) {
         Intent().putExtra(Extras.EXTRA_QUIZ_TYPE, adapter!!.words[position].second as Parcelable)
-        val dialog = WordDetailDialogFragment(subDI)
+        val dialog = WordDetailDialogFragment(di)
         val bundle = Bundle()
         bundle.putLong(Extras.EXTRA_WORD_ID, adapter!!.words[position].first.id)
         bundle.putSerializable(Extras.EXTRA_QUIZ_TYPE, if (presenter.hasMistaken()) null else adapter!!.words[position].second)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -470,7 +470,7 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
                     }
 
                     override fun onAnimationEnd(animation: Animator) {
-                        binding.check.visibility = View.GONE
+                        binding.check.visibility = GONE
                         if (result) {
                             presenter.onNextWord()
                         } else {
@@ -492,7 +492,7 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
             }
 
             override fun onAnimationStart(animation: Animator) {
-                binding.check.visibility = View.VISIBLE
+                binding.check.visibility = VISIBLE
             }
 
         }).start()
@@ -505,13 +505,13 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
     }
 
     override fun displayQCMMode() {
-        binding.qcmContainer.visibility = View.VISIBLE
-        binding.editContainer.visibility = View.GONE
+        binding.qcmContainer.visibility = VISIBLE
+        binding.editContainer.visibility = GONE
     }
 
     override fun displayEditMode() {
-        binding.qcmContainer.visibility = View.GONE
-        binding.editContainer.visibility = View.VISIBLE
+        binding.qcmContainer.visibility = GONE
+        binding.editContainer.visibility = VISIBLE
     }
 
     override fun displayQCMNormalTextViews() {
@@ -520,25 +520,25 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
         binding.option2Tv.textSize = pref.getString("font_size", "18")!!.toFloat()
         binding.option3Tv.textSize = pref.getString("font_size", "18")!!.toFloat()
         binding.option4Tv.textSize = pref.getString("font_size", "18")!!.toFloat()
-        binding.option1Tv.visibility = View.VISIBLE
-        binding.option2Tv.visibility = View.VISIBLE
-        binding.option3Tv.visibility = View.VISIBLE
-        binding.option4Tv.visibility = View.VISIBLE
-        binding.option1Furi.visibility = View.GONE
-        binding.option2Furi.visibility = View.GONE
-        binding.option3Furi.visibility = View.GONE
-        binding.option4Furi.visibility = View.GONE
+        binding.option1Tv.visibility = VISIBLE
+        binding.option2Tv.visibility = VISIBLE
+        binding.option3Tv.visibility = VISIBLE
+        binding.option4Tv.visibility = VISIBLE
+        binding.option1Furi.visibility = GONE
+        binding.option2Furi.visibility = GONE
+        binding.option3Furi.visibility = GONE
+        binding.option4Furi.visibility = GONE
     }
 
     override fun displayQCMFuriTextViews() {
-        binding.option1Tv.visibility = View.GONE
-        binding.option2Tv.visibility = View.GONE
-        binding.option3Tv.visibility = View.GONE
-        binding.option4Tv.visibility = View.GONE
-        binding.option1Furi.visibility = View.VISIBLE
-        binding.option2Furi.visibility = View.VISIBLE
-        binding.option3Furi.visibility = View.VISIBLE
-        binding.option4Furi.visibility = View.VISIBLE
+        binding.option1Tv.visibility = GONE
+        binding.option2Tv.visibility = GONE
+        binding.option3Tv.visibility = GONE
+        binding.option4Tv.visibility = GONE
+        binding.option1Furi.visibility = VISIBLE
+        binding.option2Furi.visibility = VISIBLE
+        binding.option3Furi.visibility = VISIBLE
+        binding.option4Furi.visibility = VISIBLE
     }
 
     override fun displayQCMTv1(option: String, color: Int) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
@@ -2,6 +2,7 @@ package com.jehutyno.yomikata.screens.quiz
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.util.Log
@@ -80,11 +81,29 @@ class QuizPresenter(
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         quizView.reInitUI()
         hasMistaken = savedInstanceState.getBoolean("hasMistaken")
-        answers = savedInstanceState.getParcelableArrayList("errors")!!
-        val random0 : Word? = savedInstanceState.getParcelable("random0")
-        val random1 : Word? = savedInstanceState.getParcelable("random1")
-        val random2 : Word? = savedInstanceState.getParcelable("random2")
-        val random3 : Word? = savedInstanceState.getParcelable("random3")
+
+        val random0: Word?
+        val random1: Word?
+        val random2: Word?
+        val random3: Word?
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            answers = savedInstanceState.getParcelableArrayList("errors", Answer::class.java)!!
+            random0 = savedInstanceState.getParcelable("random0", Word::class.java)
+            random1 = savedInstanceState.getParcelable("random1", Word::class.java)
+            random2 = savedInstanceState.getParcelable("random2", Word::class.java)
+            random3 = savedInstanceState.getParcelable("random3", Word::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            answers = savedInstanceState.getParcelableArrayList("errors")!!
+            @Suppress("DEPRECATION")
+            random0 = savedInstanceState.getParcelable("random0")
+            @Suppress("DEPRECATION")
+            random1 = savedInstanceState.getParcelable("random1")
+            @Suppress("DEPRECATION")
+            random2 = savedInstanceState.getParcelable("random2")
+            @Suppress("DEPRECATION")
+            random3 = savedInstanceState.getParcelable("random3")
+        }
         if (random0 != null) randoms.add(Pair(random0, savedInstanceState.getInt("random0_color")))
         if (random1 != null) randoms.add(Pair(random1, savedInstanceState.getInt("random1_color")))
         if (random2 != null) randoms.add(Pair(random2, savedInstanceState.getInt("random2_color")))

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
@@ -336,31 +336,26 @@ class QuizPresenter(
         val returnTypes: IntArray
         if (quizTypes.contains(QuizType.TYPE_AUTO.type)) {
             val autoTypes = arrayListOf<Int>()
-            if (defaultSharedPreferences.getBoolean(Prefs.FULL_VERSION.pref, false)) {
-                when (word.level) {
-                    0 -> {
-                        autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
-                        autoTypes.add(QuizType.TYPE_JAP_EN.type)
-                    }
-                    1 -> {
-                        autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
-                        autoTypes.add(QuizType.TYPE_JAP_EN.type)
-                        autoTypes.add(QuizType.TYPE_EN_JAP.type)
-                        if (ttsSupported != TextToSpeech.LANG_MISSING_DATA && ttsSupported != TextToSpeech.LANG_NOT_SUPPORTED)
-                            autoTypes.add(QuizType.TYPE_AUDIO.type)
-                    }
-                    else -> {
-                        autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
-                        autoTypes.add(QuizType.TYPE_JAP_EN.type)
-                        autoTypes.add(QuizType.TYPE_EN_JAP.type)
-                        autoTypes.add(QuizType.TYPE_PRONUNCIATION.type)
-                        if (ttsSupported != TextToSpeech.LANG_MISSING_DATA && ttsSupported != TextToSpeech.LANG_NOT_SUPPORTED)
-                            autoTypes.add(QuizType.TYPE_AUDIO.type)
-                    }
+            when (word.level) {
+                0 -> {
+                    autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
+                    autoTypes.add(QuizType.TYPE_JAP_EN.type)
                 }
-            } else {
-                autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
-                autoTypes.add(QuizType.TYPE_PRONUNCIATION.type)
+                1 -> {
+                    autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
+                    autoTypes.add(QuizType.TYPE_JAP_EN.type)
+                    autoTypes.add(QuizType.TYPE_EN_JAP.type)
+                    if (ttsSupported != TextToSpeech.LANG_MISSING_DATA && ttsSupported != TextToSpeech.LANG_NOT_SUPPORTED)
+                        autoTypes.add(QuizType.TYPE_AUDIO.type)
+                }
+                else -> {
+                    autoTypes.add(QuizType.TYPE_PRONUNCIATION_QCM.type)
+                    autoTypes.add(QuizType.TYPE_JAP_EN.type)
+                    autoTypes.add(QuizType.TYPE_EN_JAP.type)
+                    autoTypes.add(QuizType.TYPE_PRONUNCIATION.type)
+                    if (ttsSupported != TextToSpeech.LANG_MISSING_DATA && ttsSupported != TextToSpeech.LANG_NOT_SUPPORTED)
+                        autoTypes.add(QuizType.TYPE_AUDIO.type)
+                }
             }
             returnTypes = autoTypes.toIntArray()
         } else {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
@@ -108,8 +108,19 @@ class QuizPresenter(
         if (random1 != null) randoms.add(Pair(random1, savedInstanceState.getInt("random1_color")))
         if (random2 != null) randoms.add(Pair(random2, savedInstanceState.getInt("random2_color")))
         if (random3 != null) randoms.add(Pair(random3, savedInstanceState.getInt("random3_color")))
-        val words = LocalPersistence.readObjectFromFile(context, "words") as ArrayList<Word>
-        val types = LocalPersistence.readObjectFromFile(context, "types") as ArrayList<QuizType>
+
+        val wordsListRaw = LocalPersistence.readObjectFromFile(context, "words")
+        val wordsList = wordsListRaw as ArrayList<*>
+        val words = wordsListRaw.filterIsInstance<Word>()
+        if (words.size != wordsList.size) {
+            Log.e("Failed cast", "Some items in the read list of words were not of the type Word")
+        }
+        val typesListRaw = LocalPersistence.readObjectFromFile(context, "types")
+        val typesList = typesListRaw as ArrayList<*>
+        val types = typesListRaw.filterIsInstance<QuizType>()
+        if (types.size != typesList.size) {
+            Log.e("Failed cast", "Some items in the read list of quiz types were not of the type QuizType")
+        }
 
         quizWords = (0..words.size - 1).map { Pair(words[it], types[it]) }
         quizView.displayWords(quizWords)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/quizPresenterModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/quizPresenterModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.screens.quiz
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
 /**
  * Created by valentin on 18/10/2016.
  */
-fun quizPresenterModule(view: QuizContract.View) = Kodein.Module {
+fun quizPresenterModule(view: QuizContract.View) = DI.Module("quizPresenterModule") {
     bind<QuizContract.View>() with instance(view)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -200,9 +200,9 @@ class QuizzesActivity : AppCompatActivity(), DIAware {
         setupDrawerContent(binding.navView)
 
         // keep all fragments loaded for performance reasons
-        binding.pagerQuizzes.offscreenPageLimit = 10
+//        binding.pagerQuizzes.offscreenPageLimit = 10
 
-        quizzesAdapter = QuizzesPagerAdapter(this, supportFragmentManager, lifecycle, di)
+        quizzesAdapter = QuizzesPagerAdapter(this, di)
         binding.pagerQuizzes.adapter = quizzesAdapter
         binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(selectedCategory)
         binding.pagerQuizzes.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -35,6 +35,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import android.window.OnBackInvokedDispatcher
 import androidx.activity.addCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.PreferenceManager
 import androidx.viewpager2.widget.ViewPager2
@@ -363,7 +364,7 @@ class QuizzesActivity : AppCompatActivity() {
                 R.id.settings -> {
                     menuItem.isChecked = false
                     val intent = Intent(this, PrefsActivity::class.java)
-                    startActivityForResult(intent, REQUEST_PREFS)
+                    getResult.launch(intent)
                 }
                 else -> {
                 }
@@ -511,12 +512,13 @@ class QuizzesActivity : AppCompatActivity() {
         quizzesAdapter.notifyDataSetChanged()
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        when (requestCode) {
-            REQUEST_PREFS -> if (resultCode == Activity.RESULT_OK) tutos()
-        }
-    }
+    private val getResult =
+            registerForActivityResult(
+                    ActivityResultContracts.StartActivityForResult()
+            ) {
+                if (it.resultCode == Activity.RESULT_OK)
+                    tutos()
+            }
 
     override fun onPause() {
         super.onPause()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
@@ -297,7 +298,12 @@ class QuizzesActivity : AppCompatActivity() {
     }
 
     private fun setupDrawerContent(navigationView: NavigationView) {
-        navigationView.getHeaderView(0).findViewById<TextView>(R.id.version).text = getString(R.string.yomiakataz_drawer, packageManager.getPackageInfo(packageName, 0).versionName)
+        val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION") packageManager.getPackageInfo(packageName, 0)
+        }
+        navigationView.getHeaderView(0).findViewById<TextView>(R.id.version).text = getString(R.string.yomiakataz_drawer, packageInfo.versionName)
         navigationView.getHeaderView(0).findViewById<ImageView>(R.id.facebook).setOnClickListener { contactFacebook(this) }
         navigationView.getHeaderView(0).findViewById<ImageView>(R.id.discord).setOnClickListener { contactDiscord(this) }
         navigationView.getHeaderView(0).findViewById<ImageView>(R.id.play_store).setOnClickListener { contactPlayStore(this) }
@@ -369,7 +375,7 @@ class QuizzesActivity : AppCompatActivity() {
         navigationView.menu.findItem(R.id.day_night_item).actionView?.findViewById<SwitchCompat>(R.id.my_switch)?.isChecked = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES
         navigationView.menu.findItem(R.id.day_night_item).isChecked = AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES
         navigationView.menu.findItem(R.id.day_night_item).actionView?.findViewById<SwitchCompat>(R.id.my_switch)?.setOnCheckedChangeListener {
-            switch, isChecked ->
+            _, isChecked ->
             navigationView.menu.findItem(R.id.day_night_item).isChecked = isChecked
             val pref = PreferenceManager.getDefaultSharedPreferences(this)
             if (isChecked) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -155,6 +155,7 @@ class QuizzesActivity : AppCompatActivity(), DIAware {
 
         // progressBar for database update
         progressBar = ProgressBar(this, null, android.R.style.Widget_ProgressBar_Horizontal)
+        progressBar.setPadding(40, progressBar.paddingTop, 40, progressBar.paddingBottom)
 
         // Register Sync Receivers
         if (!receiversRegistered) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -193,12 +193,16 @@ class QuizzesActivity : AppCompatActivity() {
         binding.drawerLayout.setStatusBarBackground(R.color.colorPrimaryDark)
         setupDrawerContent(binding.navView)
 
+        // keep all fragments loaded for performance reasons
+        binding.pagerQuizzes.offscreenPageLimit = 10
+
         quizzesAdapter = QuizzesPagerAdapter(this, supportFragmentManager, lifecycle)
         binding.pagerQuizzes.adapter = quizzesAdapter
         binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(selectedCategory)
         binding.pagerQuizzes.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
 
             override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
                 selectedCategory = quizzesAdapter.categories[position]
                 if (selectedCategory == Categories.HOME) {
                     binding.multipleActions.visibility = GONE

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -317,50 +317,51 @@ class QuizzesActivity : AppCompatActivity() {
 
         navigationView.setNavigationItemSelectedListener { menuItem ->
             binding.multipleActions.collapse()
+            // set smoothScroll to false because scrolling through all of the pages can be bad for performance
             when (menuItem.itemId) {
                 R.id.home -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.HOME)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.HOME), false)
                 }
                 R.id.your_selections_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_SELECTIONS)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_SELECTIONS), false)
                 }
                 R.id.hiragana_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_HIRAGANA)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_HIRAGANA), false)
                 }
                 R.id.katakana_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_KATAKANA)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_KATAKANA), false)
                 }
                 R.id.kanji_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_KANJI)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_KANJI), false)
                 }
                 R.id.counters_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_COUNTERS)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_COUNTERS), false)
                 }
                 R.id.jlpt1_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_1)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_1), false)
                 }
                 R.id.jlpt2_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_2)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_2), false)
                 }
                 R.id.jlpt3_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_3)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_3), false)
                 }
                 R.id.jlpt4_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_4)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_4), false)
                 }
                 R.id.jlpt5_item -> {
                     menuItem.isChecked = true
-                    binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_5)
+                    binding.pagerQuizzes.setCurrentItem(quizzesAdapter.positionFromCategory(Categories.CATEGORY_JLPT_5), false)
                 }
                 R.id.day_night_item -> {
                     menuItem.isChecked = !menuItem.isChecked

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -48,7 +48,6 @@ import com.jehutyno.yomikata.screens.PrefsActivity
 import com.jehutyno.yomikata.screens.content.QuizzesPagerAdapter
 import com.jehutyno.yomikata.screens.search.SearchResultActivity
 import com.jehutyno.yomikata.util.*
-import com.jehutyno.yomikata.util.Extras.REQUEST_PREFS
 import com.jehutyno.yomikata.view.AppBarStateChangeListener
 import com.wooplr.spotlight.utils.SpotlightListener
 import mu.KLogging
@@ -129,7 +128,9 @@ class QuizzesActivity : AppCompatActivity() {
 
 
     fun voicesDownload(level: Int) {
-        launchVoicesDownload(this, level) {quizzesAdapter.notifyDataSetChanged()}
+        launchVoicesDownload(this, level) {
+            quizzesAdapter.notifyDataSetChanged()
+        }
     }
 
     @SuppressLint("MissingSuperCall")

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -51,11 +51,16 @@ import com.jehutyno.yomikata.util.*
 import com.jehutyno.yomikata.view.AppBarStateChangeListener
 import com.wooplr.spotlight.utils.SpotlightListener
 import mu.KLogging
+import org.kodein.di.DIAware
+import org.kodein.di.DI
+import org.kodein.di.android.di
 import splitties.alertdialog.appcompat.*
 import java.util.*
 
 
-class QuizzesActivity : AppCompatActivity() {
+class QuizzesActivity : AppCompatActivity(), DIAware {
+
+    override val di: DI by di()
 
     companion object : KLogging() {
         val UPDATE_INTENT = "update_intent"
@@ -197,7 +202,7 @@ class QuizzesActivity : AppCompatActivity() {
         // keep all fragments loaded for performance reasons
         binding.pagerQuizzes.offscreenPageLimit = 10
 
-        quizzesAdapter = QuizzesPagerAdapter(this, supportFragmentManager, lifecycle)
+        quizzesAdapter = QuizzesPagerAdapter(this, supportFragmentManager, lifecycle, di)
         binding.pagerQuizzes.adapter = quizzesAdapter
         binding.pagerQuizzes.currentItem = quizzesAdapter.positionFromCategory(selectedCategory)
         binding.pagerQuizzes.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -31,6 +32,8 @@ import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.window.OnBackInvokedDispatcher
+import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.PreferenceManager
 import androidx.viewpager2.widget.ViewPager2
@@ -41,7 +44,6 @@ import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.databinding.ActivityQuizzesBinding
 import com.jehutyno.yomikata.screens.PrefsActivity
 import com.jehutyno.yomikata.screens.content.QuizzesPagerAdapter
-import com.jehutyno.yomikata.screens.home.HomeFragment
 import com.jehutyno.yomikata.screens.search.SearchResultActivity
 import com.jehutyno.yomikata.util.*
 import com.jehutyno.yomikata.util.Extras.REQUEST_PREFS
@@ -248,6 +250,35 @@ class QuizzesActivity : AppCompatActivity() {
             }
 
         })
+
+        fun collapseOrQuit() {
+            if (binding.multipleActions.isExpanded)
+                binding.multipleActions.collapse()
+            else
+                alertDialog {
+                    titleResource = R.string.app_quit
+                    okButton { finishAffinity() }
+                    cancelButton()
+                    setOnKeyListener { _, keyCode, _ ->
+                        if (keyCode == KeyEvent.KEYCODE_BACK)
+                            finishAffinity()
+                        true
+                    }
+                }.show()
+        }
+
+        // set back button to close floating actions menu or show alertDialog
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            onBackInvokedDispatcher.registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_DEFAULT
+            ) {
+                collapseOrQuit()
+            }
+        } else {
+            onBackPressedDispatcher.addCallback(this) {
+                collapseOrQuit()
+            }
+        }
 
     }
 
@@ -462,22 +493,6 @@ class QuizzesActivity : AppCompatActivity() {
             }
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        if (binding.multipleActions.isExpanded)
-            binding.multipleActions.collapse()
-        else
-            alertDialog {
-                titleResource = R.string.app_quit
-                okButton { finishAffinity() }
-                cancelButton()
-                setOnKeyListener { _, keyCode, _ ->
-                    if (keyCode == KeyEvent.KEYCODE_BACK)
-                        finishAffinity()
-                    true
-                }
-            }.show()
     }
 
     fun gotoCategory(category: Int) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesActivity.kt
@@ -127,9 +127,10 @@ class QuizzesActivity : AppCompatActivity() {
     private lateinit var binding: ActivityQuizzesBinding
 
 
-    fun voicesDownload(level: Int) {
+    fun voicesDownload(level: Int, onSuccess: () -> Unit) {
         launchVoicesDownload(this, level) {
             quizzesAdapter.notifyDataSetChanged()
+            onSuccess()
         }
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesAdapter.kt
@@ -26,14 +26,14 @@ class QuizzesAdapter(val context: Context, val category: Int, private val callba
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val layoutInflater = LayoutInflater.from(parent.context)
 
-        when (viewType) {
+        return when (viewType) {
             TYPE_NEW_SELECTION -> {
                 val binding = VhNewSelectionBinding.inflate(layoutInflater, parent, false)
-                return ViewHolder.ViewHolderNewSelection(binding)
+                ViewHolder.ViewHolderNewSelection(binding)
             }
             TYPE_QUIZ -> {
                 val binding = VhQuizBinding.inflate(layoutInflater, parent, false)
-                return ViewHolder.ViewHolderQuiz(binding)
+                ViewHolder.ViewHolderQuiz(binding)
             }
             else -> throw IllegalArgumentException("Invalid ViewType Provided")
         }
@@ -90,31 +90,33 @@ class QuizzesAdapter(val context: Context, val category: Int, private val callba
     }
 
     override fun getItemCount(): Int {
-        if (isSelections)
-            return items.count() + 1
+        return if (isSelections)
+            items.count() + 1
         else
-            return items.count()
+            items.count()
 
     }
 
     override fun getItemViewType(position: Int): Int {
-        if (isSelections && position == items.count())
-            return TYPE_NEW_SELECTION
+        return if (isSelections && position == items.count())
+            TYPE_NEW_SELECTION
         else
-            return TYPE_QUIZ
+            TYPE_QUIZ
     }
 
     fun replaceData(list: List<Quiz>, isSelections: Boolean) {
         this.isSelections = isSelections
         items.clear()
         items.addAll(list)
+        @Suppress("notifyDataSetChanged")
         notifyDataSetChanged()
     }
 
     fun noData(isSelections: Boolean) {
         this.isSelections = isSelections
+        val size = items.size
         items.clear()
-        notifyDataSetChanged()
+        notifyItemRangeRemoved(0, size)
     }
 
     sealed class ViewHolder(binding: ViewBinding) : RecyclerView.ViewHolder(binding.root) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesAdapter.kt
@@ -66,7 +66,7 @@ class QuizzesAdapter(val context: Context, val category: Int, private val callba
                     true
                 }
                 holder.quizCheck.setOnCheckedChangeListener {
-                    compoundButton, b ->
+                    _, b ->
                     if (category != Categories.CATEGORY_SELECTIONS) {
                         if (!flag) {
                             run {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -100,6 +100,13 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         adapter = QuizzesAdapter(requireActivity(), selectedCategory, this, selectedCategory == Categories.CATEGORY_SELECTIONS)
     }
 
+    override fun onStart() {
+        // use onStart so that viewPager2 can set everything up before the page becomes visible
+        super.onStart()
+        mpresenter!!.start()
+        mpresenter!!.loadQuizzes(selectedCategory)
+    }
+
     override fun onResume() {
         super.onResume()
         val position = (binding.recyclerview.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -1,6 +1,5 @@
 package com.jehutyno.yomikata.screens.quizzes
 
-import android.animation.ObjectAnimator
 import android.content.Intent
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
@@ -46,39 +45,8 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     private var tts: TextToSpeech? = null
     private var ttsSupported: Int = TextToSpeech.LANG_NOT_SUPPORTED
 
-    /**
-     * Singleton used to keep track of the seekBars settings / animations.
-     */
-    private object SeekBars {
-        var seekLowAnimation : ObjectAnimator? = null
-        var seekMediumAnimation : ObjectAnimator? = null
-        var seekHighAnimation : ObjectAnimator? = null
-        var seekMasterAnimation : ObjectAnimator? = null
-
-        var count : Int = 0
-        var low : Int = 0
-        var medium : Int = 0
-        var high : Int = 0
-        var master : Int = 0
-
-        fun animateAll(binding: FragmentQuizzesBinding) {
-            seekLowAnimation = animateSeekBar(binding.seekLow, 0, low, count)
-            seekMediumAnimation = animateSeekBar(binding.seekMedium, 0, medium, count)
-            seekHighAnimation = animateSeekBar(binding.seekHigh, 0, high, count)
-            seekMasterAnimation = animateSeekBar(binding.seekMaster, 0, master, count)
-        }
-
-        /**
-         * Cancel all animations of the seekBars.
-         * Use before manually setting seekBar.progress = value (since the animation may override your value)
-         */
-        fun cancelAll() {
-            seekLowAnimation?.cancel()
-            seekMediumAnimation?.cancel()
-            seekHighAnimation?.cancel()
-            seekMasterAnimation?.cancel()
-        }
-    }
+    // seekBars
+    private lateinit var seekBars : SeekBarsManager
 
     // View Binding
     private var _binding: FragmentQuizzesBinding? = null
@@ -112,7 +80,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         val position = (binding.recyclerview.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
         mpresenter!!.start()
         mpresenter!!.loadQuizzes(selectedCategory)
-        SeekBars.animateAll(binding)    // call this after loadQuizzes, since SeekBars variables are set there
+        seekBars.animateAll()    // call this after loadQuizzes, since seekBars variables are set there
         binding.recyclerview.scrollToPosition(position)
         tutos()
     }
@@ -121,7 +89,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         super.onPause()
 
         // cancel animation in case it is currently running
-        SeekBars.cancelAll()
+        seekBars.cancelAll()
 
         // set all to zero to prepare for the next animation when the page resumes again
         binding.seekLow.progress = 0
@@ -215,6 +183,9 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
                 cancelButton { }
             }.show()
         }
+
+        // initialize seekBarsManager
+        seekBars = SeekBarsManager(binding.seekLow, binding.seekMedium, binding.seekHigh, binding.seekMaster)
     }
 
     private fun previousVoicesDownloaded(downloadVersion: Int): Boolean {
@@ -294,21 +265,21 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             ids.add(it.id)
         }
 
-        SeekBars.count = mpresenter!!.countQuiz(ids.toLongArray())
-        SeekBars.low = mpresenter!!.countLow(ids.toLongArray())
-        SeekBars.medium = mpresenter!!.countMedium(ids.toLongArray())
-        SeekBars.high = mpresenter!!.countHigh(ids.toLongArray())
-        SeekBars.master = mpresenter!!.countMaster(ids.toLongArray())
+        seekBars.count = mpresenter!!.countQuiz(ids.toLongArray())
+        seekBars.low = mpresenter!!.countLow(ids.toLongArray())
+        seekBars.medium = mpresenter!!.countMedium(ids.toLongArray())
+        seekBars.high = mpresenter!!.countHigh(ids.toLongArray())
+        seekBars.master = mpresenter!!.countMaster(ids.toLongArray())
 
-        binding.textLow.text = SeekBars.low.toString()
-        binding.textMedium.text = SeekBars.medium.toString()
-        binding.textHigh.text = SeekBars.high.toString()
-        binding.textMaster.text = SeekBars.master.toString()
+        binding.textLow.text = seekBars.low.toString()
+        binding.textMedium.text = seekBars.medium.toString()
+        binding.textHigh.text = seekBars.high.toString()
+        binding.textMaster.text = seekBars.master.toString()
 
-        binding.playLow.visibility = if (SeekBars.low > 0) VISIBLE else INVISIBLE
-        binding.playMedium.visibility = if (SeekBars.medium > 0) VISIBLE else INVISIBLE
-        binding.playHigh.visibility = if (SeekBars.high > 0) VISIBLE else INVISIBLE
-        binding.playMaster.visibility = if (SeekBars.master > 0) VISIBLE else INVISIBLE
+        binding.playLow.visibility = if (seekBars.low > 0) VISIBLE else INVISIBLE
+        binding.playMedium.visibility = if (seekBars.medium > 0) VISIBLE else INVISIBLE
+        binding.playHigh.visibility = if (seekBars.high > 0) VISIBLE else INVISIBLE
+        binding.playMaster.visibility = if (seekBars.master > 0) VISIBLE else INVISIBLE
     }
 
     private fun openContent(position: Int, level: Int) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -133,7 +133,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             openContent(selectedCategory, 3)
         }
 
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         if (selectedCategory == -1 || selectedCategory == 8
             || pref.getBoolean(Prefs.VOICE_DOWNLOADED_LEVEL_V.pref +
             "${getLevelDownloadVersion(getCategoryLevel(selectedCategory))}_${getCategoryLevel(selectedCategory)}", false)) {
@@ -163,7 +163,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
     }
 
     fun previousVoicesDownloaded(downloadVersion: Int): Boolean {
-        val pref = PreferenceManager.getDefaultSharedPreferences(context)
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         return (0 until downloadVersion).any {
             pref.getBoolean("${Prefs.VOICE_DOWNLOADED_LEVEL_V.pref}${it}_${getCategoryLevel(selectedCategory)}", false)
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -71,6 +71,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         mpresenter!!.start()
         mpresenter!!.loadQuizzes(selectedCategory)
         binding.recyclerview.scrollToPosition(position)
+        tutos()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -83,6 +83,9 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         seekBars.animateAll()    // call this after loadQuizzes, since seekBars variables are set there
         binding.recyclerview.scrollToPosition(position)
         tutos()
+
+        // check if voices downloads have changed (e.g. voices files have been deleted in preferences)
+        updateVoicesDownloadVisibility()
     }
 
     override fun onPause() {
@@ -156,19 +159,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
             openContent(selectedCategory, 3)
         }
 
-        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
-        if (selectedCategory == -1 || selectedCategory == 8
-            || pref.getBoolean(Prefs.VOICE_DOWNLOADED_LEVEL_V.pref +
-            "${getLevelDownloadVersion(getCategoryLevel(selectedCategory))}_${getCategoryLevel(selectedCategory)}", false)) {
-            binding.download.visibility = GONE
-        } else {
-            binding.download.visibility = VISIBLE
-            if (getLevelDownloadVersion(getCategoryLevel(selectedCategory)) > 0 && previousVoicesDownloaded(getLevelDownloadVersion(getCategoryLevel(selectedCategory)))) {
-                binding.download.text = getString(R.string.update_voices, getLevelDownloadSize(getCategoryLevel(selectedCategory)))
-            } else {
-                binding.download.text = getString(R.string.download_voices, getLevelDownloadSize(getCategoryLevel(selectedCategory)))
-            }
-        }
+        updateVoicesDownloadVisibility()
 
         binding.download.setOnClickListener {
             requireContext().alertDialog {
@@ -190,6 +181,22 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
 
         // initialize seekBarsManager
         seekBars = SeekBarsManager(binding.seekLow, binding.seekMedium, binding.seekHigh, binding.seekMaster)
+    }
+
+    private fun updateVoicesDownloadVisibility() {
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        if (selectedCategory == -1 || selectedCategory == 8
+                || pref.getBoolean(Prefs.VOICE_DOWNLOADED_LEVEL_V.pref +
+                        "${getLevelDownloadVersion(getCategoryLevel(selectedCategory))}_${getCategoryLevel(selectedCategory)}", false)) {
+            binding.download.visibility = GONE
+        } else {
+            binding.download.visibility = VISIBLE
+            if (getLevelDownloadVersion(getCategoryLevel(selectedCategory)) > 0 && previousVoicesDownloaded(getLevelDownloadVersion(getCategoryLevel(selectedCategory)))) {
+                binding.download.text = getString(R.string.update_voices, getLevelDownloadSize(getCategoryLevel(selectedCategory)))
+            } else {
+                binding.download.text = getString(R.string.download_voices, getLevelDownloadSize(getCategoryLevel(selectedCategory)))
+            }
+        }
     }
 
     private fun previousVoicesDownloaded(downloadVersion: Int): Boolean {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -117,6 +117,19 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         tutos()
     }
 
+    override fun onPause() {
+        super.onPause()
+
+        // cancel animation in case it is currently running
+        SeekBars.cancelAll()
+
+        // set all to zero to prepare for the next animation when the page resumes again
+        binding.seekLow.progress = 0
+        binding.seekMedium.progress = 0
+        binding.seekHigh.progress = 0
+        binding.seekMaster.progress = 0
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentQuizzesBinding.inflate(inflater, container, false)
         return binding.root

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -101,9 +101,8 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         }
         binding.btnAudioSwitch.setOnClickListener {
             spotlightTuto(requireActivity(), binding.btnAudioSwitch, getString(R.string.tutos_audio_quiz), getString(R.string.tutos_audio_quiz_message), SpotlightListener { })
-            val speechAvailability = checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(selectedCategory))
-            when (speechAvailability) {
-                SpeechAvailability.NOT_AVAILABLE -> speechNotSupportedAlert(requireActivity(), getCategoryLevel(selectedCategory), { (activity as QuizzesActivity).quizzesAdapter.notifyDataSetChanged() })
+            when (checkSpeechAvailability(requireActivity(), ttsSupported, getCategoryLevel(selectedCategory))) {
+                SpeechAvailability.NOT_AVAILABLE -> speechNotSupportedAlert(requireActivity(), getCategoryLevel(selectedCategory)) { (activity as QuizzesActivity).quizzesAdapter.notifyDataSetChanged() }
                 else -> mpresenter!!.audioSwitch()
             }
         }
@@ -162,7 +161,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         }
     }
 
-    fun previousVoicesDownloaded(downloadVersion: Int): Boolean {
+    private fun previousVoicesDownloaded(downloadVersion: Int): Boolean {
         val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         return (0 until downloadVersion).any {
             pref.getBoolean("${Prefs.VOICE_DOWNLOADED_LEVEL_V.pref}${it}_${getCategoryLevel(selectedCategory)}", false)
@@ -259,7 +258,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         binding.playMaster.visibility = if (master > 0) VISIBLE else INVISIBLE
     }
 
-    fun openContent(position: Int, level: Int) {
+    private fun openContent(position: Int, level: Int) {
         if ((selectedCategory == Categories.CATEGORY_SELECTIONS)) {
             // TODO: ?
         } else {
@@ -401,7 +400,7 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
         _binding = null
     }
 
-    fun tutos() {
+    private fun tutos() {
         MainScope().async {
             withContext(IO) {
                 sleep(500)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesFragment.kt
@@ -179,7 +179,11 @@ class QuizzesFragment : Fragment(), QuizzesContract.View, QuizzesAdapter.Callbac
                     titleResource = R.string.download_voices_alert
                     message = getString(R.string.download_voices_alert_message, getLevelDownloadSize(getCategoryLevel(selectedCategory)))
                 }
-                okButton { (activity as QuizzesActivity).voicesDownload(getCategoryLevel(selectedCategory)) }
+                okButton {
+                    (activity as QuizzesActivity).voicesDownload(getCategoryLevel(selectedCategory)) {
+                        binding.download.visibility = GONE
+                    }
+                }
                 cancelButton { }
             }.show()
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
@@ -4,10 +4,9 @@ import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
-import androidx.viewpager.widget.PagerAdapter
 import android.util.SparseArray
-import android.view.ViewGroup
+import androidx.lifecycle.Lifecycle
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.screens.home.HomeFragment
 import com.jehutyno.yomikata.screens.quizzes.QuizzesFragment
@@ -18,7 +17,7 @@ import com.jehutyno.yomikata.util.Extras
 /**
  * Created by valentin on 19/12/2016.
  */
-class QuizzesPagerAdapter(val context: Context, fm: FragmentManager) : FragmentStatePagerAdapter(fm) {
+class QuizzesPagerAdapter(val context: Context, fm: FragmentManager, lifecycle: Lifecycle) : FragmentStateAdapter(fm, lifecycle) {
 
     val categories = intArrayOf(Categories.HOME,
         Categories.CATEGORY_SELECTIONS,
@@ -31,37 +30,22 @@ class QuizzesPagerAdapter(val context: Context, fm: FragmentManager) : FragmentS
         Categories.CATEGORY_JLPT_3,
         Categories.CATEGORY_JLPT_2,
         Categories.CATEGORY_JLPT_1)
-    val registered: SparseArray<Fragment> = SparseArray()
+//    val registered: SparseArray<Fragment> = SparseArray()
 
-    override fun getItem(position: Int): Fragment {
-        if (position == 0) {
-            return HomeFragment()
+    override fun getItemCount(): Int {
+        return categories.size
+    }
+
+    override fun createFragment(position: Int): Fragment {
+        return if (categories[position] == Categories.HOME) {
+            HomeFragment()
         } else {
             val bundle = Bundle()
             bundle.putInt(Extras.EXTRA_CATEGORY, categories[position])
             val quizzesFragment = QuizzesFragment()
             quizzesFragment.arguments = bundle
-            return quizzesFragment
+            quizzesFragment
         }
-    }
-
-    override fun instantiateItem(container: ViewGroup, position: Int): Any {
-        val fragment = super.instantiateItem(container, position) as Fragment
-        registered.put(position, fragment)
-        return fragment
-    }
-
-    override fun getCount(): Int {
-        return categories.size
-    }
-
-    override fun getItemPosition(`object`: Any): Int {
-        return PagerAdapter.POSITION_NONE
-    }
-
-    override fun destroyItem(container: ViewGroup, position: Int, view: Any) {
-        registered.remove(position)
-        super.destroyItem(container, position, view)
     }
 
     fun positionFromCategory(selectedCategory: Int): Int {
@@ -77,22 +61,6 @@ class QuizzesPagerAdapter(val context: Context, fm: FragmentManager) : FragmentS
             Categories.CATEGORY_JLPT_3 -> 8
             Categories.CATEGORY_JLPT_2 -> 9
             else -> 10
-        }
-    }
-
-    fun categoryFromPosition(position: Int): Int {
-        return when (position) {
-            0 -> Categories.HOME
-            1 -> Categories.CATEGORY_SELECTIONS
-            2 -> Categories.CATEGORY_HIRAGANA
-            3 -> Categories.CATEGORY_KATAKANA
-            4 -> Categories.CATEGORY_KANJI
-            5 -> Categories.CATEGORY_COUNTERS
-            6 -> Categories.CATEGORY_JLPT_5
-            7 -> Categories.CATEGORY_JLPT_4
-            8 -> Categories.CATEGORY_JLPT_3
-            9 -> Categories.CATEGORY_JLPT_2
-            else -> Categories.CATEGORY_JLPT_1
         }
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
@@ -1,13 +1,11 @@
 package com.jehutyno.yomikata.screens.content
 
-import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.screens.home.HomeFragment
+import com.jehutyno.yomikata.screens.quizzes.QuizzesActivity
 import com.jehutyno.yomikata.screens.quizzes.QuizzesFragment
 import com.jehutyno.yomikata.util.Categories
 import com.jehutyno.yomikata.util.Extras
@@ -17,7 +15,7 @@ import org.kodein.di.DI
 /**
  * Created by valentin on 19/12/2016.
  */
-class QuizzesPagerAdapter(val context: Context, fm: FragmentManager, lifecycle: Lifecycle, private val di: DI) : FragmentStateAdapter(fm, lifecycle) {
+class QuizzesPagerAdapter(activity: QuizzesActivity, private val di: DI) : FragmentStateAdapter(activity) {
 
     val categories = intArrayOf(Categories.HOME,
         Categories.CATEGORY_SELECTIONS,

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
-import android.util.SparseArray
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.jehutyno.yomikata.R

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPagerAdapter.kt
@@ -11,12 +11,13 @@ import com.jehutyno.yomikata.screens.home.HomeFragment
 import com.jehutyno.yomikata.screens.quizzes.QuizzesFragment
 import com.jehutyno.yomikata.util.Categories
 import com.jehutyno.yomikata.util.Extras
+import org.kodein.di.DI
 
 
 /**
  * Created by valentin on 19/12/2016.
  */
-class QuizzesPagerAdapter(val context: Context, fm: FragmentManager, lifecycle: Lifecycle) : FragmentStateAdapter(fm, lifecycle) {
+class QuizzesPagerAdapter(val context: Context, fm: FragmentManager, lifecycle: Lifecycle, private val di: DI) : FragmentStateAdapter(fm, lifecycle) {
 
     val categories = intArrayOf(Categories.HOME,
         Categories.CATEGORY_SELECTIONS,
@@ -37,11 +38,11 @@ class QuizzesPagerAdapter(val context: Context, fm: FragmentManager, lifecycle: 
 
     override fun createFragment(position: Int): Fragment {
         return if (categories[position] == Categories.HOME) {
-            HomeFragment()
+            HomeFragment(di)
         } else {
             val bundle = Bundle()
             bundle.putInt(Extras.EXTRA_CATEGORY, categories[position])
-            val quizzesFragment = QuizzesFragment()
+            val quizzesFragment = QuizzesFragment(di)
             quizzesFragment.arguments = bundle
             quizzesFragment
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPresenterModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quizzes/QuizzesPresenterModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.screens.quizzes
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
 /**
  * Created by valentin on 29/09/2016.
  */
-fun quizzesPresenterModule(view: QuizzesContract.View) = Kodein.Module {
+fun quizzesPresenterModule(view: QuizzesContract.View) = DI.Module("quizzesPresenterModule") {
     bind<QuizzesContract.View>() with instance(view)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultActivity.kt
@@ -41,11 +41,11 @@ class SearchResultActivity : AppCompatActivity() {
             title = getString(R.string.search_title)
         }
 
-        if (savedInstanceState != null) {
+        searchResultFragment = if (savedInstanceState != null) {
             //Restore the fragment's instance
-            searchResultFragment = supportFragmentManager.getFragment(savedInstanceState, "searchResultFragment") as SearchResultFragment
+            supportFragmentManager.getFragment(savedInstanceState, "searchResultFragment") as SearchResultFragment
         } else {
-            searchResultFragment = SearchResultFragment()
+            SearchResultFragment()
         }
         addOrReplaceFragment(R.id.container_content, searchResultFragment)
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
@@ -19,13 +19,14 @@ import com.jehutyno.yomikata.screens.content.WordsAdapter
 import com.jehutyno.yomikata.screens.content.word.WordDetailDialogFragment
 import com.jehutyno.yomikata.util.DimensionHelper
 import com.jehutyno.yomikata.util.Extras
+import org.kodein.di.DI
 import splitties.alertdialog.appcompat.*
 import java.util.*
 
 /**
  * Created by valentin on 13/10/2016.
  */
-class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter.Callback {
+class SearchResultFragment(private val di: DI) : Fragment(), SearchResultContract.View, WordsAdapter.Callback {
     private lateinit var searchResultPresenter : SearchResultContract.Presenter
     private lateinit var adapter: WordsAdapter
     private lateinit var layoutManager: LinearLayoutManager
@@ -127,7 +128,7 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
         bundle.putInt(Extras.EXTRA_WORD_POSITION, position)
         bundle.putString(Extras.EXTRA_SEARCH_STRING, searchString)
 
-        val dialog = WordDetailDialogFragment()
+        val dialog = WordDetailDialogFragment(di)
         dialog.arguments = bundle
         dialog.show(childFragmentManager, "")
         dialog.isCancelable = true

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultFragment.kt
@@ -142,25 +142,22 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
         searchResultPresenter.updateWordCheck(adapter.items[position].id, check)
     }
 
-    val actionModeCallback = object : ActionMode.Callback {
+    private val actionModeCallback = object : ActionMode.Callback {
         override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
             adapter.checkMode = true
-            adapter.notifyDataSetChanged()
+            adapter.notifyItemRangeChanged(0, adapter.items.size)
             return false
         }
 
+        private val ADD_TO_SELECTIONS = 1
+        private val REMOVE_FROM_SELECTIONS = 2
+        private val SELECT_ALL = 3
+        private val UNSELECT_ALL = 4
+
         override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
             when (item.itemId) {
-                3 -> {
-                    adapter.items.forEach { it.isSelected = 1 }
-                    adapter.notifyDataSetChanged()
-                }
-                4 -> {
-                    adapter.items.forEach { it.isSelected = 0 }
-                    adapter.notifyDataSetChanged()
-                }
-                1 -> {
-                    val popup = PopupMenu(activity!!, activity!!.findViewById(1))
+                ADD_TO_SELECTIONS -> {
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(item.itemId))
                     popup.menuInflater.inflate(R.menu.popup_selections, popup.menu)
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
@@ -182,10 +179,9 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
                         true
                     }
                     popup.show()
-
                 }
-                2 -> {
-                    val popup = PopupMenu(activity!!, activity!!.findViewById(2))
+                REMOVE_FROM_SELECTIONS -> {
+                    val popup = PopupMenu(activity!!, activity!!.findViewById(item.itemId))
                     for ((i, selection) in selections.withIndex()) {
                         popup.menu.add(1, i, i, selection.getName()).isChecked = false
                     }
@@ -205,7 +201,14 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
                         true
                     }
                     popup.show()
-
+                }
+                SELECT_ALL -> {
+                    adapter.items.forEach { it.isSelected = 1 }
+                    adapter.notifyItemRangeChanged(0, adapter.items.size)
+                }
+                UNSELECT_ALL -> {
+                    adapter.items.forEach { it.isSelected = 0 }
+                    adapter.notifyItemRangeChanged(0, adapter.items.size)
                 }
             }
             return false
@@ -241,20 +244,20 @@ class SearchResultFragment : Fragment(), SearchResultContract.View, WordsAdapter
 
         override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
             mode.title = null
-            menu.add(0, 1, 0, getString(R.string.add_to_selections)).setIcon(R.drawable.ic_selections_selected)
+            menu.add(0, ADD_TO_SELECTIONS, 0, getString(R.string.add_to_selections)).setIcon(R.drawable.ic_selections_selected)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            menu.add(0, 2, 0, getString(R.string.remove_from_selection)).setIcon(R.drawable.ic_unselect)
+            menu.add(0, REMOVE_FROM_SELECTIONS, 0, getString(R.string.remove_from_selection)).setIcon(R.drawable.ic_unselect)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            menu.add(0, 3, 0, getString(R.string.select_all)).setIcon(R.drawable.ic_select_multiple)
+            menu.add(0, SELECT_ALL, 0, getString(R.string.select_all)).setIcon(R.drawable.ic_select_multiple)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
-            menu.add(0, 4, 0, getString(R.string.unselect_all)).setIcon(R.drawable.ic_unselect_multiple)
+            menu.add(0, UNSELECT_ALL, 0, getString(R.string.unselect_all)).setIcon(R.drawable.ic_unselect_multiple)
                 .setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
             return true
         }
 
         override fun onDestroyActionMode(mode: ActionMode?) {
             adapter.checkMode = false
-            adapter.notifyDataSetChanged()
+            adapter.notifyItemRangeChanged(0, adapter.items.size)
         }
     }
 

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultPresenterModule.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/search/SearchResultPresenterModule.kt
@@ -1,11 +1,12 @@
 package com.jehutyno.yomikata.screens.search
 
-import com.github.salomonbrys.kodein.Kodein
-import com.github.salomonbrys.kodein.instance
+import org.kodein.di.DI
+import org.kodein.di.bind
+import org.kodein.di.instance
 
 /**
  * Created by valentin on 13/10/2016.
  */
-fun searchResultPresenterModule(view: SearchResultContract.View) = Kodein.Module {
+fun searchResultPresenterModule(view: SearchResultContract.View) = DI.Module("searchResultPresenterModule") {
     bind<SearchResultContract.View>() with instance(view)
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
@@ -252,7 +252,12 @@ private fun createGpButton(activity: Activity) : Button {
     gpButton.setOnClickListener {
         val manager = activity.packageManager
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(activity.getString(R.string.google_tts_uri)))
-        if (manager.queryIntentActivities(intent, 0).size == 0) {
+        val query = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            manager.queryIntentActivities(intent, PackageManager.ResolveInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION") manager.queryIntentActivities(intent, 0)
+        }
+        if (query.size == 0) {
             val toast = Toast.makeText(activity,R.string.action_not_possible, Toast.LENGTH_LONG)
             toast.show()
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
@@ -5,7 +5,9 @@ package com.jehutyno.yomikata.util
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.speech.tts.TextToSpeech
 import android.util.Log
 import android.view.Gravity
@@ -42,8 +44,13 @@ fun reportError(context: Activity, word: Word, sentence: Sentence) {
     i.putExtra(Intent.EXTRA_EMAIL, arrayOf<String>(context.getString(R.string.email_contact)))
     i.putExtra(Intent.EXTRA_SUBJECT, context.getString(R.string.error_mail_subject))
     val sb = StringBuilder()
+    val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0))
+    } else {
+        @Suppress("DEPRECATION") context.packageManager.getPackageInfo(context.packageName, 0)
+    }
     sb.append(context.getString(R.string.error_mail_body_1))
-            .append("App version: V").append(context.packageManager.getPackageInfo(context.packageName, 0).versionName).append("\n")
+            .append("App version: V").append(packageInfo.versionName).append("\n")
             .append("Word Id: ").append(word.id).append(" | ").append("Quiz Id: ").append(word.baseCategory)
             .append(" | ").append(word.japanese).append(" | ").append(word.reading).append("\n")
             .append("Sentence Id: ").append(sentence.id).append("\n")
@@ -87,7 +94,12 @@ fun contactEmail(context: Context) {
 
 fun contactFacebook(context: Context?) {
     try {
-        context?.packageManager?.getPackageInfo("com.facebook.katana", 0)
+        val packageName = "com.facebook.katana"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context?.packageManager?.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION") context?.packageManager?.getPackageInfo(packageName, 0)
+        }
         context?.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("fb://page/412201938791197")).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
     } catch (e: Exception) {
         context?.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("https://www.facebook.com/YomikataAndroid")).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK))

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
@@ -3,7 +3,6 @@
 package com.jehutyno.yomikata.util
 
 import android.app.Activity
-import android.app.ProgressDialog
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -14,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
+import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
@@ -27,6 +27,7 @@ import com.wooplr.spotlight.SpotlightView
 import com.wooplr.spotlight.prefs.PreferencesManager
 import com.wooplr.spotlight.utils.SpotlightListener
 import splitties.alertdialog.appcompat.*
+import splitties.views.horizontalPadding
 import java.io.File
 import java.util.*
 
@@ -288,13 +289,17 @@ fun launchVoicesDownload(activity: Activity, level: Int, finishedListener: () ->
     val localFile = File.createTempFile(fileName, ".zip")
     val unzipPath = FileUtils.getDataDir(activity, "Voices").absolutePath
 
-    val progressDialog = ProgressDialog(activity)
-    progressDialog.max = 100
-    progressDialog.setTitle(activity.getString(R.string.voice_download_progress))
-    progressDialog.setMessage(activity.getString(R.string.voices_download_progress_message))
-    progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL)
-    progressDialog.setCancelable(false)
-    progressDialog.show()
+    val progressBar = ProgressBar(activity, null, android.R.attr.progressBarStyleHorizontal)
+    progressBar.horizontalPadding = 40
+    progressBar.max = 100
+
+    val progressAlertDialog = activity.alertDialog {
+        titleResource = R.string.voice_download_progress
+        messageResource = R.string.voices_download_progress_message
+        setCancelable(false)
+        setView(progressBar)
+    }
+    progressAlertDialog.show()
 
     reference.getFile(localFile).addOnSuccessListener {
         FileDownloadService.unzip(localFile.absolutePath, unzipPath)
@@ -304,7 +309,7 @@ fun launchVoicesDownload(activity: Activity, level: Int, finishedListener: () ->
         val pref = PreferenceManager.getDefaultSharedPreferences(activity)
         pref.edit().putBoolean(Prefs.VOICE_DOWNLOADED_LEVEL_V.pref +
                 "${getLevelDownloadVersion(level)}_$level", true).apply()
-        progressDialog.dismiss()
+        progressAlertDialog.dismiss()
 
         activity.alertDialog {
             titleResource = R.string.download_success
@@ -314,7 +319,7 @@ fun launchVoicesDownload(activity: Activity, level: Int, finishedListener: () ->
         }.show()
 
     }.addOnFailureListener {
-        progressDialog.dismiss()
+        progressAlertDialog.dismiss()
 
         activity.alertDialog {
             titleResource = R.string.download_failed
@@ -324,7 +329,7 @@ fun launchVoicesDownload(activity: Activity, level: Int, finishedListener: () ->
 
     }.addOnProgressListener {
         val progress: Double = 100.0 * it.bytesTransferred / it.totalByteCount
-        progressDialog!!.progress = progress.toInt()
+        progressBar!!.progress = progress.toInt()
     }
 
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
@@ -333,6 +333,7 @@ fun launchVoicesDownload(activity: Activity, level: Int, finishedListener: () ->
             messageResource = R.string.download_success_message
 
             okButton { finishedListener() }
+            setOnCancelListener { finishedListener() }
         }.show()
 
     }.addOnFailureListener {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/ActionsUtils.kt
@@ -29,7 +29,6 @@ import com.wooplr.spotlight.SpotlightView
 import com.wooplr.spotlight.prefs.PreferencesManager
 import com.wooplr.spotlight.utils.SpotlightListener
 import splitties.alertdialog.appcompat.*
-import splitties.views.horizontalPadding
 import java.io.File
 import java.util.*
 
@@ -307,7 +306,7 @@ fun launchVoicesDownload(activity: Activity, level: Int, finishedListener: () ->
     val unzipPath = FileUtils.getDataDir(activity, "Voices").absolutePath
 
     val progressBar = ProgressBar(activity, null, android.R.attr.progressBarStyleHorizontal)
-    progressBar.horizontalPadding = 40
+    progressBar.setPadding(40, progressBar.paddingTop, 40, progressBar.paddingBottom)
     progressBar.max = 100
 
     val progressAlertDialog = activity.alertDialog {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/AnimationUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/AnimationUtils.kt
@@ -7,13 +7,14 @@ import android.widget.SeekBar
 /**
  * Created by valentin on 27/10/2016.
  */
-fun animateSeekBar(seekBar: SeekBar, from: Int, to: Int, max: Int) {
+fun animateSeekBar(seekBar: SeekBar, from: Int, to: Int, max: Int) : ObjectAnimator {
     seekBar.max = if (max < 10) max * 10 else max
     seekBar.progress = from
     val animation = ObjectAnimator.ofInt(seekBar, "progress", if (max < 10) to * 10 else to)
-    animation.startDelay = 300
+    animation.startDelay = 0
     animation.duration = 700
     animation.interpolator = DecelerateInterpolator()
     animation.start()
     seekBar.isEnabled = false
+    return animation
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/AppCompatActivityUtils.kt
@@ -75,7 +75,7 @@ fun Activity.migrateFromYomikata() {
                     wordTable.forEach { word ->
                         val source = WordSource(context)
                         if (word.counterTry > 0 || word.priority > 0)
-                            source.restoreWord(word.word, word.prononciation, word)
+                            source.restoreWord(word.word, word.pronunciation, word)
                     }
                 }
                 File(toPath + toName).delete()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/Prefs.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/Prefs.kt
@@ -14,7 +14,6 @@ enum class Prefs(val pref: String) {
     TTS_RATE("tts_rate"),
     LATEST_CATEGORY_1("latest_category_1"),
     LATEST_CATEGORY_2("latest_category_2"),
-    FULL_VERSION("full_version"),
     DB_UPDATE_ONGOING("db_update_ongoing"),
     DB_UPDATE_FILE("db_update_file"),
     DB_UPDATE_OLD_VERSION("db_update_old_version"),

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/SeekBarsManager.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/SeekBarsManager.kt
@@ -1,0 +1,40 @@
+package com.jehutyno.yomikata.util
+
+import android.animation.ObjectAnimator
+import android.widget.SeekBar
+
+/**
+ * Used to keep track of the seekBars settings / animations.
+ */
+class SeekBarsManager(private val seekLow: SeekBar, private val seekMedium: SeekBar,
+                      private val seekHigh: SeekBar, private val seekMaster: SeekBar) {
+
+    var seekLowAnimation : ObjectAnimator? = null
+    var seekMediumAnimation : ObjectAnimator? = null
+    var seekHighAnimation : ObjectAnimator? = null
+    var seekMasterAnimation : ObjectAnimator? = null
+
+    var count : Int = 0
+    var low : Int = 0
+    var medium : Int = 0
+    var high : Int = 0
+    var master : Int = 0
+
+    fun animateAll() {
+        seekLowAnimation = animateSeekBar(seekLow, 0, low, count)
+        seekMediumAnimation = animateSeekBar(seekMedium, 0, medium, count)
+        seekHighAnimation = animateSeekBar(seekHigh, 0, high, count)
+        seekMasterAnimation = animateSeekBar(seekMaster, 0, master, count)
+    }
+
+    /**
+     * Cancel all animations of the seekBars.
+     * Use before manually setting seekBar.progress = value (since the animation may override your value)
+     */
+    fun cancelAll() {
+        seekLowAnimation?.cancel()
+        seekMediumAnimation?.cancel()
+        seekHighAnimation?.cancel()
+        seekMasterAnimation?.cancel()
+    }
+}

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/SortUtils.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/SortUtils.kt
@@ -1,6 +1,7 @@
 package com.jehutyno.yomikata.util
 
 import java.util.*
+import kotlin.math.roundToInt
 
 /**
  * Created by valentin on 21/10/2016.
@@ -38,6 +39,6 @@ fun <T>shuffle(items:MutableList<T>):List<T>{
  * @param maxValue
  */
 fun randomNumericArray(length: Int, maxValue : Int = 10) : Array<Int>{
-    return Array<Int>(length, {i -> Math.round(maxValue * Math.random()).toInt() })
+    return Array(length) { (maxValue * Math.random()).roundToInt() }
 }
 

--- a/app/src/main/res/layout/activity_content.xml
+++ b/app/src/main/res/layout/activity_content.xml
@@ -26,7 +26,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-        <androidx.viewpager.widget.ViewPager
+        <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/pager_content"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/activity_quizzes.xml
+++ b/app/src/main/res/layout/activity_quizzes.xml
@@ -116,7 +116,7 @@
                         android:layout_marginLeft="-15dp"
                         android:layout_marginStart="-15dp"/>
 
-                    <androidx.viewpager.widget.ViewPager
+                    <androidx.viewpager2.widget.ViewPager2
                         android:id="@+id/pager_quizzes"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -158,9 +158,6 @@
     <string name="orange_review">Mots oranges</string>
     <string name="yellow_review">Mots jaunes</string>
     <string name="green_review">Mots verts</string>
-    <string name="action_unlock">Débloquer la version complète</string>
-    <string name="selection_unlock_full_version">Pour créer vos propres sélections, veuillez débloquer la version complète depuis l\'écran principal</string>
-    <string name="purchase_unlock">Débloquer</string>
     <string name="unlock_caps">DEBLOQUER</string>
     <string name="cancel_caps">ANNULER</string>
     <string name="error_billing">Oups ! Veuillez vérifier que vous êtes connecté ou que votre appareil supporte les Google Play Services !</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,9 +185,6 @@
     <string name="orange_review">Orange review</string>
     <string name="yellow_review">Yellow review</string>
     <string name="green_review">Green review</string>
-    <string name="action_unlock">Unlock full version</string>
-    <string name="selection_unlock_full_version">To create your own selections, please unlock the full version from the Home screen</string>
-    <string name="purchase_unlock">Unlock</string>
     <string name="unlock_caps">UNLOCK</string>
     <string name="cancel_caps">CANCEL</string>
     <string name="error_billing">Oops !  Please check that you are online or that your device support the Google Play Services </string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+org.gradle.warning.mode=all
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
+org.gradle.unsafe.configuration-cache=true
 org.gradle.warning.mode=all
 
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
Upgraded a bunch of minor deprecated function calls.

Migrated the viewpager FragmentStatePagerAdapters to viewpager2 FragmentStateAdapters:
viewpager2 has slightly different behaviour compared to viewpager: the onResume() method of the fragments is now only called when the fragment is fully selected (user no longer scrolling). This means some of the setup functions have to also be called in onStart() so that the fragment looks loaded as the user is scrolling.
The animations of the seekBars will now play when the fragment is selected, instead of while scrolling.

Other changes:
- Upgraded kodein to a newer version.
- Fixed problem where voices download button would not immediately (dis)appear when deleting/downloading voice files.
- Some changes in AndroidManifest: removed redundant package name (only needed in build.gradle) and added query for google tts services
- Clicking on a Quizzes category in the navigation screen will no longer play the scrolling animation, because loading all of the fragments while scrolling can be quite slow
- Changed some of the notifyDataSetChanged() calls to be more specific
- Removed some leftover FullVersion code