### PR TITLE
Multiple choice click to reveal

### DIFF
--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/PrefsActivity.kt
@@ -121,6 +121,9 @@ class PrefsActivity : AppCompatActivity(), FileChooserDialog.ChooserListener {
                 "length" -> {
                     return true
                 }
+                "tap_to_reveal" -> {
+                    return true
+                }
                 "play_start" -> {
                     return true
                 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizContract.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizContract.kt
@@ -20,7 +20,7 @@ interface QuizContract {
         fun selectionLoaded(quizzes: List<Quiz>)
         fun noSelections()
         fun setHiraganaConversion(enabled: Boolean)
-        fun displayQCMMode()
+        fun displayQCMMode(hintText: String? = null)
         fun displayEditMode()
         fun displayQCMNormalTextViews()
         fun displayQCMFuriTextViews()

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -335,6 +335,7 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
     private fun initAnswersButtons() {
         binding.quizContainer.setOnClickListener { if (isSettingsOpen) closeTTSSettings() }
         binding.answerContainer.setOnClickListener { if (isSettingsOpen) closeTTSSettings() }
+        binding.quizAnswerType.visibility = GONE
         binding.tapToReveal.setOnClickListener { it.visibility = GONE }
         binding.tapToReveal.visibility = GONE
         qcmBinding.option1Container.setOnClickListener {
@@ -509,19 +510,24 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
         editBinding.editAction.setColorFilter(ContextCompat.getColor(requireActivity(), R.color.level_master_4))
     }
 
-    override fun displayQCMMode() {
+    override fun displayQCMMode(hintText: String?) {
         qcmBinding.root.visibility = VISIBLE
         editBinding.root.visibility = GONE
         val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
         if (pref.getBoolean("tap_to_reveal", false)) {
             binding.tapToReveal.visibility = VISIBLE
+            binding.quizAnswerType.visibility = VISIBLE
+            // say what type of answer should be found
+            if (hintText != null)
+                binding.quizAnswerType.text = hintText
         } else {
             binding.tapToReveal.visibility = GONE
+            binding.quizAnswerType.visibility = GONE
         }
     }
 
     override fun displayEditMode() {
-
+        binding.quizAnswerType.visibility = GONE
         qcmBinding.root.visibility = GONE
         editBinding.root.visibility = VISIBLE
     }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -332,6 +332,8 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
     private fun initAnswersButtons() {
         binding.quizContainer.setOnClickListener { if (isSettingsOpen) closeTTSSettings() }
         binding.answerContainer.setOnClickListener { if (isSettingsOpen) closeTTSSettings() }
+        binding.tapToReveal.setOnClickListener { it.visibility = GONE }
+        binding.tapToReveal.visibility = GONE
         binding.option1Container.setOnClickListener {
             if (isSettingsOpen) closeTTSSettings()
             if (!holdOn) {
@@ -507,6 +509,12 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, QuizItem
     override fun displayQCMMode() {
         binding.qcmContainer.visibility = VISIBLE
         binding.editContainer.visibility = GONE
+        val pref = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        if (pref.getBoolean("tap_to_reveal", false)) {
+            binding.tapToReveal.visibility = VISIBLE
+        } else {
+            binding.tapToReveal.visibility = GONE
+        }
     }
 
     override fun displayEditMode() {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
@@ -208,7 +208,10 @@ class QuizPresenter(
             QuizType.TYPE_PRONUNCIATION_QCM -> {
                 // Keyboard
                 quizView.hideKeyboard()
-                quizView.displayQCMMode()
+                quizView.displayQCMMode(if (word.isKana == 0)
+                                            context.getString(R.string.give_hiragana_reading_hint)
+                                        else
+                                            context.getString(R.string.give_romaji_hint))
                 // TTS at start
                 if (defaultSharedPreferences.getBoolean("play_start", false))
                     quizView.speakWord(if (errorMode) errors[currentItem].first else quizWords[currentItem].first)
@@ -219,7 +222,7 @@ class QuizPresenter(
             QuizType.TYPE_AUDIO -> {
                 // Keyboard
                 quizView.hideKeyboard()
-                quizView.displayQCMMode()
+                quizView.displayQCMMode(context.getString(R.string.give_word_or_kanji_hint))
                 // TTS at start
                 quizView.speakWord(if (errorMode) errors[currentItem].first else quizWords[currentItem].first)
                 // QCM options
@@ -229,7 +232,7 @@ class QuizPresenter(
             QuizType.TYPE_EN_JAP -> {
                 // Keyboard
                 quizView.hideKeyboard()
-                quizView.displayQCMMode()
+                quizView.displayQCMMode(context.getString(R.string.translate_to_japanese_hint))
                 // TTS at stat
                 if (defaultSharedPreferences.getBoolean("play_start", false))
                     quizView.speakWord(if (errorMode) errors[currentItem].first else quizWords[currentItem].first)
@@ -240,7 +243,7 @@ class QuizPresenter(
             QuizType.TYPE_JAP_EN -> {
                 // Keyboard
                 quizView.hideKeyboard()
-                quizView.displayQCMMode()
+                quizView.displayQCMMode(context.getString(R.string.translate_to_english_hint))
                 // TTS at start
                 if (defaultSharedPreferences.getBoolean("play_start", false))
                     quizView.speakWord(if (errorMode) errors[currentItem].first else quizWords[currentItem].first)

--- a/app/src/main/res/drawable-notnight/ic_visibility_black_24dp.xml
+++ b/app/src/main/res/drawable-notnight/ic_visibility_black_24dp.xml
@@ -4,6 +4,6 @@
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path
-        android:fillColor="#FFFFFFFF"
+        android:fillColor="#FF000000"
         android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_quiz.xml
+++ b/app/src/main/res/layout/fragment_quiz.xml
@@ -94,6 +94,18 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true">
 
+        <TextView
+            android:id="@+id/tap_to_reveal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:textColor="@color/lighter_gray"
+            android:textSize="22sp"
+            android:background="@drawable/rounded_bg"
+            android:gravity="center"
+            android:text="@string/tap_to_reveal_choices"
+            android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+            android:translationZ="10dp" />
+
         <LinearLayout
             android:id="@+id/edit_container"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_quiz.xml
+++ b/app/src/main/res/layout/fragment_quiz.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -88,7 +87,7 @@
 
     </FrameLayout>
 
-    <FrameLayout
+    <RelativeLayout
         android:id="@+id/answer_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -195,130 +194,33 @@
 
                 </FrameLayout>
 
-                <FrameLayout
-                    android:id="@+id/option_2_container"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    android:layout_marginLeft="8dp"
-                    android:layout_marginStart="8dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/rounded_bg"
-                    android:foreground="?attr/selectableItemBackground">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/quiz_answer_type">
 
-                    <com.jehutyno.yomikata.furigana.FuriganaView
-                        android:id="@+id/option_2_furi"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:gravity="center"
-                        android:maxLines="10"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
+            <include
+                android:id="@+id/quiz_answers_keyboard_entry"
+                layout="@layout/quiz_answers_keyboard_entry"/>
 
-                    <TextView
-                        android:id="@+id/option_2_tv"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:foreground="?attr/selectableItemBackgroundBorderless"
-                        android:gravity="center"
-                        android:maxLines="10"
-                        android:scrollbars="vertical"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
+            <include
+                android:id="@+id/quiz_answers_multiple_choice"
+                layout="@layout/quiz_answers_multiple_choice"/>
 
-                </FrameLayout>
-
-            </LinearLayout>
-
-            <LinearLayout
+            <TextView
+                android:id="@+id/tap_to_reveal"
                 android:layout_width="match_parent"
-                android:layout_height="100dp"
-                android:orientation="horizontal"
-                android:paddingTop="16dp">
+                android:layout_height="match_parent"
+                android:textColor="@color/lighter_gray"
+                android:textSize="22sp"
+                android:background="@drawable/rounded_bg"
+                android:gravity="center"
+                android:text="@string/tap_to_reveal_choices"
+                android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+                android:visibility="gone"/>
 
-                <FrameLayout
-                    android:id="@+id/option_3_container"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginRight="8dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/rounded_bg"
-                    android:foreground="?attr/selectableItemBackground">
+        </FrameLayout>
 
-                    <com.jehutyno.yomikata.furigana.FuriganaView
-                        android:id="@+id/option_3_furi"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:gravity="center"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
-
-                    <TextView
-                        android:id="@+id/option_3_tv"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:foreground="?attr/selectableItemBackgroundBorderless"
-                        android:gravity="center"
-                        android:maxLines="10"
-                        android:scrollbars="vertical"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
-
-                </FrameLayout>
-
-                <FrameLayout
-                    android:id="@+id/option_4_container"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    android:layout_marginLeft="8dp"
-                    android:layout_marginStart="8dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/rounded_bg"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <com.jehutyno.yomikata.furigana.FuriganaView
-                        android:id="@+id/option_4_furi"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:gravity="center"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
-
-                    <TextView
-                        android:id="@+id/option_4_tv"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:foreground="?attr/selectableItemBackgroundBorderless"
-                        android:gravity="center"
-                        android:maxLines="10"
-                        android:scrollbars="vertical"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
-
-                </FrameLayout>
-            </LinearLayout>
-        </LinearLayout>
-    </FrameLayout>
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_quiz.xml
+++ b/app/src/main/res/layout/fragment_quiz.xml
@@ -94,105 +94,15 @@
         android:layout_alignParentBottom="true">
 
         <TextView
-            android:id="@+id/tap_to_reveal"
+            android:id="@+id/quiz_answer_type"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:textColor="@color/lighter_gray"
-            android:textSize="22sp"
-            android:background="@drawable/rounded_bg"
+            android:textSize="18sp"
             android:gravity="center"
-            android:text="@string/tap_to_reveal_choices"
+            android:text="Translate to english"
             android:textAppearance="@style/TextAppearance.AppCompat.Headline"
-            android:translationZ="10dp" />
-
-        <LinearLayout
-            android:id="@+id/edit_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="16dp"
-            android:orientation="horizontal">
-
-            <com.jehutyno.hiraganaedittext.HiraganaEditText
-                android:id="@+id/hiragana_edit"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:hint="@string/quiz_input_hint"
-                android:imeOptions="flagNoExtractUi|flagNoFullscreen"
-                android:inputType="textNoSuggestions"
-                android:padding="10dp"
-                android:privateImeOptions="nm"
-                android:textColor="@color/lighter_gray"
-                android:textColorHint="@color/gray"
-                android:textSize="18sp"/>
-
-            <ImageView
-                android:id="@+id/edit_action"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:background="?attr/selectableItemBackgroundBorderless"
-                android:src="@drawable/ic_cancel_black_24dp"
-                android:tint="@color/lighter_gray"/>
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/qcm_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginStart="16dp"
-            android:orientation="vertical"
-            android:visibility="visible">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="100dp"
-                android:orientation="horizontal"
-                android:paddingTop="16dp">
-
-                <FrameLayout
-                    android:id="@+id/option_1_container"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_gravity="center"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginRight="8dp"
-                    android:layout_weight="1"
-                    android:background="@drawable/rounded_bg"
-                    android:foreground="?attr/selectableItemBackground">
-
-                    <com.jehutyno.yomikata.furigana.FuriganaView
-                        android:id="@+id/option_1_furi"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:gravity="center"
-                        android:maxLines="10"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
-
-                    <TextView
-                        android:id="@+id/option_1_tv"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_gravity="center"
-                        android:layout_margin="4dp"
-                        android:foreground="?attr/selectableItemBackgroundBorderless"
-                        android:gravity="center"
-                        android:maxLines="10"
-                        android:scrollbars="vertical"
-                        android:textColor="@color/lighter_gray"
-                        android:textSize="18sp"
-                        tools:text="trololo1"/>
-
-                </FrameLayout>
+            android:layout_marginVertical="10dp" />
 
         <FrameLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/quiz_answers_keyboard_entry.xml
+++ b/app/src/main/res/layout/quiz_answers_keyboard_entry.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/edit_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginStart="16dp"
+    android:orientation="horizontal"
+    tools:showIn="@layout/fragment_quiz">
+
+    <com.jehutyno.hiraganaedittext.HiraganaEditText
+        android:id="@+id/hiragana_edit"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:hint="@string/quiz_input_hint"
+        android:imeOptions="flagNoExtractUi|flagNoFullscreen"
+        android:inputType="textNoSuggestions"
+        android:padding="10dp"
+        android:privateImeOptions="nm"
+        android:textColor="@color/lighter_gray"
+        android:textColorHint="@color/gray"
+        android:textSize="18sp"/>
+
+    <ImageView
+        android:id="@+id/edit_action"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_cancel_black_24dp"
+        app:tint="@color/lighter_gray" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/quiz_answers_multiple_choice.xml
+++ b/app/src/main/res/layout/quiz_answers_multiple_choice.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/qcm_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:layout_marginEnd="16dp"
+    android:layout_marginStart="16dp"
+    android:orientation="vertical"
+    android:visibility="visible"
+    tools:showIn="@layout/fragment_quiz">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:orientation="horizontal"
+        android:paddingTop="16dp">
+
+        <FrameLayout
+            android:id="@+id/option_1_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_weight="1"
+            android:background="@drawable/rounded_bg"
+            android:foreground="?attr/selectableItemBackground">
+
+            <com.jehutyno.yomikata.furigana.FuriganaView
+                android:id="@+id/option_1_furi"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:gravity="center"
+                android:maxLines="10"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="furi1"/>
+
+            <TextView
+                android:id="@+id/option_1_tv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:foreground="?attr/selectableItemBackgroundBorderless"
+                android:gravity="center"
+                android:maxLines="10"
+                android:scrollbars="vertical"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="text1"/>
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/option_2_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:background="@drawable/rounded_bg"
+            android:foreground="?attr/selectableItemBackground">
+
+            <com.jehutyno.yomikata.furigana.FuriganaView
+                android:id="@+id/option_2_furi"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:gravity="center"
+                android:maxLines="10"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="furi2"/>
+
+            <TextView
+                android:id="@+id/option_2_tv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:foreground="?attr/selectableItemBackgroundBorderless"
+                android:gravity="center"
+                android:maxLines="10"
+                android:scrollbars="vertical"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="text2" />
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:orientation="horizontal"
+        android:paddingTop="16dp">
+
+        <FrameLayout
+            android:id="@+id/option_3_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_weight="1"
+            android:background="@drawable/rounded_bg"
+            android:foreground="?attr/selectableItemBackground">
+
+            <com.jehutyno.yomikata.furigana.FuriganaView
+                android:id="@+id/option_3_furi"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:gravity="center"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="furi3" />
+
+            <TextView
+                android:id="@+id/option_3_tv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:foreground="?attr/selectableItemBackgroundBorderless"
+                android:gravity="center"
+                android:maxLines="10"
+                android:scrollbars="vertical"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="text3" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/option_4_container"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_weight="1"
+            android:background="@drawable/rounded_bg"
+            android:foreground="?attr/selectableItemBackground">
+
+            <com.jehutyno.yomikata.furigana.FuriganaView
+                android:id="@+id/option_4_furi"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:gravity="center"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="furi4" />
+
+            <TextView
+                android:id="@+id/option_4_tv"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_margin="4dp"
+                android:foreground="?attr/selectableItemBackgroundBorderless"
+                android:gravity="center"
+                android:maxLines="10"
+                android:scrollbars="vertical"
+                android:textColor="@color/lighter_gray"
+                android:textSize="18sp"
+                tools:text="text4" />
+
+        </FrameLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -197,9 +197,9 @@
     <string name="dont_ask_voices">Ne plus demander</string>
     <string name="voices_reinit_done">Fichiers de voix supprimés</string>
     <string name="tap_to_reveal_choices">Appuyez pour révéler les choix</string>
-    <string name="tap_to_reveal_choices_summary">Masquez les options de choix multiples jusqu\'au moment où vous touchez l\'écran</string>
+    <string name="tap_to_reveal_choices_summary">Les choix sont cachés jusqu\'à ce que vous touchiez l\'écran</string>
     <string name="give_hiragana_reading_hint">Donnez la lecture en hiragana</string>
-    <string name="give_romaji_hint">Donnez le rōmaji</string>
+    <string name="give_romaji_hint">Donnez la lecture en rōmaji</string>
     <string name="give_word_or_kanji_hint">Donnez le mot ou le kanji</string>
     <string name="translate_to_japanese_hint">Traduisez en Japonais</string>
     <string name="translate_to_english_hint">Traduisez en Français</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -196,4 +196,6 @@
     <string name="delete_voices_files">Effacer les fichiers de voix</string>
     <string name="dont_ask_voices">Ne plus demander</string>
     <string name="voices_reinit_done">Fichiers de voix supprimés</string>
+    <string name="tap_to_reveal_choices">Appuyez pour révéler les choix</string>
+    <string name="tap_to_reveal_choices_summary">Masquez les options de choix multiples jusqu\'au moment où vous touchez l\'écran</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -198,4 +198,9 @@
     <string name="voices_reinit_done">Fichiers de voix supprimés</string>
     <string name="tap_to_reveal_choices">Appuyez pour révéler les choix</string>
     <string name="tap_to_reveal_choices_summary">Masquez les options de choix multiples jusqu\'au moment où vous touchez l\'écran</string>
+    <string name="give_hiragana_reading_hint">Donnez la lecture en hiragana</string>
+    <string name="give_romaji_hint">Donnez le rōmaji</string>
+    <string name="give_word_or_kanji_hint">Donnez le mot ou le kanji</string>
+    <string name="translate_to_japanese_hint">Traduisez en Japonais</string>
+    <string name="translate_to_english_hint">Traduisez en Français</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,4 +223,6 @@
     <string name="delete_voices_files">Delete voices files</string>
     <string name="dont_ask_voices">Don\'t ask again</string>
     <string name="voices_reinit_done">Voice files have been deleted</string>
+    <string name="tap_to_reveal_choices">Tap to reveal choices</string>
+    <string name="tap_to_reveal_choices_summary">Hide multiple choice options until you tap the screen</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,4 +225,9 @@
     <string name="voices_reinit_done">Voice files have been deleted</string>
     <string name="tap_to_reveal_choices">Tap to reveal choices</string>
     <string name="tap_to_reveal_choices_summary">Hide multiple choice options until you tap the screen</string>
+    <string name="give_hiragana_reading_hint">Give hiragana reading</string>
+    <string name="give_romaji_hint">Give rōmaji</string>
+    <string name="give_word_or_kanji_hint">Give word or kanji</string>
+    <string name="translate_to_japanese_hint">Translate to Japanese</string>
+    <string name="translate_to_english_hint">Translate to English</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,7 +39,7 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
-            android:icon="@drawable/ic_quiz"
+            android:icon="@drawable/ic_visibility_black_24dp"
             android:key="tap_to_reveal"
             android:summary="@string/tap_to_reveal_choices_summary"
             android:title="@string/tap_to_reveal_choices"/>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,6 +39,13 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:icon="@drawable/ic_quiz"
+            android:key="tap_to_reveal"
+            android:summary="@string/tap_to_reveal_choices_summary"
+            android:title="@string/tap_to_reveal_choices"/>
+
+        <CheckBoxPreference
+            android:defaultValue="false"
             android:icon="@drawable/ic_ray_start"
             android:key="play_start"
             android:summary="@string/settings_play_start_summary"


### PR DESCRIPTION
Add an option to hide all multiple choice options until you tap the screen.
If you turn on this option, it also shows a hint to tell you what the type of the answer should be (see screenshots).

Also separated the fragment_quiz.xml file in to two extra files (multiple choice part and keyboard part).

(please verify the French translations)

<div>

<img src="https://user-images.githubusercontent.com/86888804/229367872-76aa7b07-7bf5-4a7c-b48e-9fc742242973.jpg" width="250">

<img src="https://user-images.githubusercontent.com/86888804/229364499-47eb10f8-7e79-49d7-b5e8-cbf711e33ae2.jpg" width="250">

<img src="https://user-images.githubusercontent.com/86888804/229364502-fedfcea7-b601-4284-bb5c-28901759ec5e.jpg" width="250">

</div>

