### PR TITLE
fix: quiz keyboard, input focus, font size. feat: quiz QoL options.

### DIFF
--- a/app/src/main/kotlin/com/jehutyno/yomikata/audio/VoicesManager.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/audio/VoicesManager.kt
@@ -6,10 +6,12 @@ import android.media.AudioManager
 import android.net.Uri
 import android.speech.tts.TextToSpeech
 import android.widget.Toast
+import androidx.preference.PreferenceManager
 import com.jehutyno.yomikata.R
 import com.jehutyno.yomikata.model.Sentence
 import com.jehutyno.yomikata.model.Word
 import com.jehutyno.yomikata.util.FileUtils
+import com.jehutyno.yomikata.util.Prefs
 import com.jehutyno.yomikata.util.SpeechAvailability
 import com.jehutyno.yomikata.util.checkSpeechAvailability
 import com.jehutyno.yomikata.util.sentenceNoFuri
@@ -21,13 +23,14 @@ import com.jehutyno.yomikata.util.quiz.getCategoryLevel
  * Created by valentinlanfranchi on 01/09/2017.
  */
 class VoicesManager(val context: Activity) {
+    private val prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
     private val exoPlayerAudio: ExoPlayerAudio = ExoPlayerAudio(context)
     private val exoPlayer = exoPlayerAudio.exoPlayer
 
     fun speakSentence(sentence: Sentence, ttsSupported: Int, tts: TextToSpeech?) {
         val audio = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        if (audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
+        if (audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0 && prefs.getBoolean(Prefs.WARN_VOLUME_TOO_LOW.pref, true)) {
             val toast = Toast.makeText(context, R.string.message_adjuste_volume, Toast.LENGTH_LONG)
             toast.show()
         }
@@ -50,7 +53,7 @@ class VoicesManager(val context: Activity) {
 
     fun speakWord(word: Word, ttsSupported: Int, tts: TextToSpeech?) {
         val audio = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        if (audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0) {
+        if (audio.getStreamVolume(AudioManager.STREAM_MUSIC) == 0 && prefs.getBoolean(Prefs.WARN_VOLUME_TOO_LOW.pref, true)) {
             val toast = Toast.makeText(context, R.string.message_adjuste_volume, Toast.LENGTH_SHORT)
             toast.show()
         }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/prefs/PrefsFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/prefs/PrefsFragment.kt
@@ -134,8 +134,8 @@ class PrefsFragment : PreferenceFragmentCompat() {
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
         when (preference.key) {
-            "font_size", "input_change", "speed", "length",
-            "tap_to_reveal", "play_start", "play_end", "analytics_consent" -> return true
+            "font_size", "show_magnified_word", "input_change", "speed", "length",
+            "tap_to_reveal", "play_start", "play_end", "analytics_consent", "automatically_continue" -> return true
 
             "reset_tuto" -> {
                 resetAllTutos(PreferenceManager.getDefaultSharedPreferences(requireActivity()))

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizContract.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizContract.kt
@@ -43,8 +43,6 @@ interface QuizContract {
         fun displayQCMTv(options: List<String>, colorIds: List<Int>)
         fun displayQCMFuri(furiNum: Int, optionFuri: String, start: Int, end: Int, colorId: Int)
         fun displayQCMFuri(options: List<String>, starts: List<Int>, ends: List<Int>, colorIds: List<Int>)
-        fun showKeyboard()
-        fun hideKeyboard()
         fun animateColor(position: Int, word: Word, sentence: Sentence, quizType: QuizType, fromPoints: Int, toPoints: Int)
         fun setEditTextColor(color: Int)
         fun animateCheck(result: Boolean)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizFragment.kt
@@ -9,7 +9,6 @@ import android.speech.tts.TextToSpeech
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -91,6 +90,8 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
     private var ttsRate by mutableStateOf(50)
     private var ttsShowRate by mutableStateOf(true)
 
+    private var warnIfVolumeTooLow by mutableStateOf(true)
+
     private lateinit var dialogFlowController: DialogFlowController
 
     // Track if answer input is busy (prevent double-submit)
@@ -102,6 +103,7 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
         // Applique la vitesse de parole sauvegardée (Prefs.TTS_RATE) au moteur dès son init,
         // sinon le réglage du panneau vocal reste sans effet pendant le quiz.
         tts?.setSpeechRate((prefs.getInt(Prefs.TTS_RATE.pref, 50) + 50).toFloat() / 100)
+        warnIfVolumeTooLow = prefs.getBoolean(Prefs.WARN_VOLUME_TOO_LOW.pref, true);
         val currentWord = uiState.currentWord
         if (currentWord != null) {
             val noPlayStart = prefs.getBoolean(Prefs.PLAY_START.pref, false)
@@ -237,6 +239,7 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
                             volume = ttsVolume,
                             maxVolume = ttsMaxVolume,
                             speechRate = ttsRate,
+                            warnIfVolumeTooLow = warnIfVolumeTooLow,
                             showSpeechRate = ttsShowRate,
                             onVolumeChange = { v ->
                                 ttsVolume = v
@@ -250,6 +253,10 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
                                 prefs.edit().putInt(Prefs.TTS_RATE.pref, r).apply()
                                 tts?.setSpeechRate((r + 50).toFloat() / 100)
                                 presenter.onSpeakSentence()
+                            },
+                            onWarnIfVolumeTooLowChange = { v ->
+                                warnIfVolumeTooLow = v
+                                prefs.edit().putBoolean(Prefs.WARN_VOLUME_TOO_LOW.pref, v).apply()
                             },
                             onDismiss = { ttsSettingsVisible = false },
                         )
@@ -270,6 +277,8 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
         uiState = uiState.copy(
             showFurigana = prefs.getBoolean(Prefs.FURI_DISPLAYED.pref, true),
             showTranslation = prefs.getBoolean(Prefs.TRAD_DISPLAYED.pref, true),
+            fontSizeSp = prefs.getString(Prefs.FONT_SIZE.pref, null)?.toFloatOrNull() ?: 23f,
+            showMagnifiedWord = prefs.getBoolean(Prefs.SHOW_MAGNIFIED_WORD.pref, true),
         )
 
         if (savedInstanceState != null) {
@@ -399,17 +408,20 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
     }
 
     override fun displayQCMMode(hintText: String?) {
-        hideKeyboard()
         uiState = uiState.copy(
             answerMode = AnswerMode.QCM,
             hintText = hintText,
             isRevealed = false,
+            showKeyboard = false,
         )
     }
 
     override fun displayEditMode() {
-        uiState = uiState.copy(answerMode = AnswerMode.Edit, isRevealed = false)
-        showKeyboard()
+        uiState = uiState.copy(
+            answerMode = AnswerMode.Edit,
+            isRevealed = false,
+            showKeyboard = true,
+        )
     }
 
     override fun displayQCMNormalTextViews() {
@@ -475,16 +487,6 @@ class QuizFragment(private val di: DI) : Fragment(), QuizContract.View, TextToSp
             },
         )
         updateRevealedFromOptions()
-    }
-
-    override fun showKeyboard() {
-        val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        view?.let { imm.showSoftInput(it, InputMethodManager.SHOW_IMPLICIT) }
-    }
-
-    override fun hideKeyboard() {
-        val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        view?.let { imm.hideSoftInputFromWindow(it.windowToken, 0) }
     }
 
     override fun animateCheck(result: Boolean) {

--- a/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/screens/quiz/QuizPresenter.kt
@@ -254,10 +254,8 @@ class QuizPresenter(
                 if (convertHiragana) {
                     quizView.setHiraganaConversion(word.isKana == 0)
                 }
-                quizView.showKeyboard()
                 quizView.displayEditMode()
             } else {
-                quizView.hideKeyboard()
                 randoms = generateQCMRandoms(word, quizType, word.reading)
 
                 qcmDisplayHint.let { text ->
@@ -512,6 +510,17 @@ class QuizPresenter(
             saveAnswerResultStat(word, result)
         }
         previousAnswerWrong = !result
+
+        if (result) {
+            if (defaultSharedPreferences.getBoolean(Prefs.PLAY_END.pref, true)) {
+                quizView.speakWord(sessionState.getCurrentWord())
+            }
+            if (defaultSharedPreferences.getBoolean(Prefs.AUTOMATICALLY_CONTINUE.pref, false)) {
+                onNextWord()
+                return;
+            }
+        }
+
         val color = if (result) R.color.level_master_4 else R.color.level_low_1
         when (quizType) {
             QuizType.TYPE_PRONUNCIATION -> {
@@ -551,9 +560,6 @@ class QuizPresenter(
             }
             QuizType.TYPE_AUTO -> TODO()
         }
-
-        if (result && defaultSharedPreferences.getBoolean(Prefs.PLAY_END.pref, true))
-            quizView.speakWord(sessionState.getCurrentWord())
 
         quizView.animateCheck(result)
     }
@@ -734,10 +740,8 @@ class QuizPresenter(
     }
 
     override fun onFinishQuiz() {
-        quizView.hideKeyboard()
         quizView.finishQuiz()
     }
-
 
     override suspend fun updateWordPoints(wordId: Long, points: Int) {
         wordStatisticsRecorder.updateWordPoints(wordId, points)

--- a/app/src/main/kotlin/com/jehutyno/yomikata/ui/quiz/QuizScreen.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/ui/quiz/QuizScreen.kt
@@ -1,10 +1,12 @@
 package com.jehutyno.yomikata.ui.quiz
 
+import android.content.Context
 import android.text.Editable
 import android.text.InputType
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
@@ -44,9 +46,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -102,6 +107,7 @@ data class QuizUiState(
     val currentIndex: Int = 0,
     val sentence: Sentence = Sentence(),
     val answerMode: AnswerMode = AnswerMode.None,
+    val showKeyboard: Boolean = false,
     val qcmOptions: List<QcmOption> = List(4) { QcmOption("") },
     val qcmShowFuri: Boolean = false,
     val hintText: String? = null,
@@ -116,6 +122,8 @@ data class QuizUiState(
     val showTranslation: Boolean = true,
     // Orange for unanswered, green after correct, stays orange after wrong (AccentOrange if 0)
     val wordHighlightColor: Int = 0,
+    val fontSizeSp: Float = 23f,
+    val showMagnifiedWord: Boolean = true,
     val infiniteCount: Int? = null,
     /** True when the current word belongs to at least one user selection (orange star). */
     val isCurrentWordInSelection: Boolean = false,
@@ -183,6 +191,13 @@ fun QuizScreen(
         },
         label = "heroBorder",
     )
+
+    val keyboard = LocalSoftwareKeyboardController.current
+    LaunchedEffect(uiState.showKeyboard) {
+        if (!uiState.showKeyboard) {
+            keyboard?.hide()
+        }
+    }
 
     Column(
         modifier = modifier
@@ -280,6 +295,8 @@ fun QuizScreen(
                 showFurigana = uiState.showFurigana,
                 showTranslation = uiState.showTranslation,
                 wordHighlightColor = uiState.wordHighlightColor,
+                fontSizeSp = uiState.fontSizeSp,
+                showMagnifiedWord = uiState.showMagnifiedWord,
                 isRevealed = uiState.isRevealed,
                 isCorrect = isCorrect,
                 isWrong = isWrong,
@@ -375,6 +392,8 @@ private fun QuestionZone(
     showFurigana: Boolean,
     showTranslation: Boolean,
     wordHighlightColor: Int,
+    fontSizeSp: Float,
+    showMagnifiedWord: Boolean,
     isRevealed: Boolean,
     isCorrect: Boolean,
     isWrong: Boolean,
@@ -390,6 +409,11 @@ private fun QuestionZone(
 ) {
     // P4: orange si non répondu, green après bonne réponse (défault si 0 → orange)
     val sentenceHighlight = if (wordHighlightColor != 0) wordHighlightColor else AccentOrange.toArgb()
+
+    // La phrase d'exemple sert de taille de base ; les autres textes de la question en dérivent.
+    val sentenceFontSp = fontSizeSp
+    val bigWordFontSp = fontSizeSp * 2.2f
+    val translationFontSp = fontSizeSp * 0.78f
 
     Column(
         modifier = modifier.padding(horizontal = 16.dp, vertical = 12.dp),
@@ -430,8 +454,8 @@ private fun QuestionZone(
                     Text(
                         text = word.getTrad().cleanForQCM(false),
                         color = AccentOrange,
-                        fontSize = 22.sp,
-                        lineHeight = 30.sp,
+                        fontSize = bigWordFontSp.sp,
+                        lineHeight = (bigWordFontSp * 1.36f).sp,
                         textAlign = TextAlign.Center,
                     )
                 }
@@ -513,22 +537,24 @@ private fun QuestionZone(
                         verticalArrangement = Arrangement.spacedBy(16.dp),
                     ) {
                         // Mot en vedette — centré, avec spring bounce + shake
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .graphicsLayer { scaleX = scale; scaleY = scale }
-                                .offset { IntOffset(shakeOffset.value.roundToInt(), 0) },
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            FuriganaAndroidView(
-                                text = largeWordText,
-                                markStart = 0,
-                                markEnd = 0,
-                                highlightColor = kanjiColor.toArgb(),
-                                textColor = kanjiColor.toArgb(),
-                                textSizeSp = 46f,
-                                modifier = Modifier.wrapContentWidth(),
-                            )
+                        if (showMagnifiedWord) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .graphicsLayer { scaleX = scale; scaleY = scale }
+                                    .offset { IntOffset(shakeOffset.value.roundToInt(), 0) },
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                FuriganaAndroidView(
+                                    text = largeWordText,
+                                    markStart = 0,
+                                    markEnd = 0,
+                                    highlightColor = kanjiColor.toArgb(),
+                                    textColor = kanjiColor.toArgb(),
+                                    textSizeSp = bigWordFontSp,
+                                    modifier = Modifier.wrapContentWidth(),
+                                )
+                            }
                         }
 
                         // Phrase d'exemple + traduction — centrées horizontalement
@@ -542,7 +568,7 @@ private fun QuestionZone(
                                 markStart = wordPos,
                                 markEnd = markEnd,
                                 highlightColor = sentenceHighlight,
-                                textSizeSp = 18f,
+                                textSizeSp = sentenceFontSp,
                                 modifier = Modifier
                                     .wrapContentWidth()
                                     .clickable(onClick = onItemClick),
@@ -550,7 +576,7 @@ private fun QuestionZone(
                             Text(
                                 text = sentence.getTrad(),
                                 color = TextSecondary,
-                                fontSize = 14.sp,
+                                fontSize = translationFontSp.sp,
                                 textAlign = TextAlign.Center,
                                 modifier = Modifier.alpha(
                                     if (showTranslation && quizType != QuizType.TYPE_JAP_EN) 1f else 0f
@@ -740,6 +766,7 @@ private fun EditAnswerMode(
     onClear: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val textInputFocusRequester = remember { FocusRequester() }
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -767,8 +794,7 @@ private fun EditAnswerMode(
                         // clavier insère un saut de ligne et ne déclenche jamais la validation
                         // (OnEditorActionListener). TYPE_CLASS_TEXT est requis pour un vrai champ texte.
                         inputType = InputType.TYPE_CLASS_TEXT or
-                                InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS or
-                                InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
+                                InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
                         imeOptions = EditorInfo.IME_ACTION_DONE
                         setSingleLine(true)
                         setTextColor(textColorInt)
@@ -806,6 +832,14 @@ private fun EditAnswerMode(
                                 true
                             } else false
                         }
+                        setOnFocusChangeListener { v, hasFocus ->
+                            if (hasFocus) {
+                                val imm = v.context.getSystemService(
+                                    Context.INPUT_METHOD_SERVICE
+                                ) as InputMethodManager
+                                imm.showSoftInput(v, 0)
+                            }
+                        }
                     }
                 },
                 update = { view ->
@@ -816,8 +850,12 @@ private fun EditAnswerMode(
                         if (text.isNotEmpty()) view.setSelection(text.length)
                     }
                 },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().focusRequester(textInputFocusRequester),
             )
+
+            LaunchedEffect(textInputFocusRequester) {
+                textInputFocusRequester.requestFocus()
+            }
         }
 
         // Révéler la réponse (« donner sa langue au chat ») : toujours disponible, même sans

--- a/app/src/main/kotlin/com/jehutyno/yomikata/ui/quiz/TtsSettingsSheet.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/ui/quiz/TtsSettingsSheet.kt
@@ -1,10 +1,13 @@
 package com.jehutyno.yomikata.ui.quiz
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -12,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -44,9 +48,11 @@ fun TtsSettingsSheet(
     volume: Int,
     maxVolume: Int,
     speechRate: Int,
+    warnIfVolumeTooLow: Boolean,
     showSpeechRate: Boolean,
     onVolumeChange: (Int) -> Unit,
     onSpeechRateChange: (Int) -> Unit,
+    onWarnIfVolumeTooLowChange: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(
@@ -54,35 +60,77 @@ fun TtsSettingsSheet(
         sheetState = rememberModalBottomSheetState(),
         containerColor = SurfacePrimary,
     ) {
-        Column(
-            modifier = Modifier
-                .padding(horizontal = 20.dp)
-                .padding(bottom = 24.dp),
-        ) {
-            SectionHeader(text = stringResource(R.string.tts_settings_title))
-            Spacer(modifier = Modifier.height(12.dp))
+        TtsSettingsSheetContent(
+            volume = volume,
+            maxVolume = maxVolume,
+            speechRate = speechRate,
+            warnIfVolumeTooLow = warnIfVolumeTooLow,
+            showSpeechRate = showSpeechRate,
+            onVolumeChange = onVolumeChange,
+            onSpeechRateChange = onSpeechRateChange,
+            onWarnIfVolumeTooLowChange = onWarnIfVolumeTooLowChange,
+        )
+    }
+}
 
-            SliderLabel(stringResource(R.string.tts_volume))
+/**
+ * Contenu du panneau de réglages vocaux, sans le [ModalBottomSheet].
+ *
+ * Séparé du wrapper pour pouvoir être prévisualisé isolément dans la preview Compose
+ * (les modal bottom sheet ne se rendent pas dans les previews isolées).
+ */
+@Composable
+private fun TtsSettingsSheetContent(
+    volume: Int,
+    maxVolume: Int,
+    speechRate: Int,
+    warnIfVolumeTooLow: Boolean,
+    showSpeechRate: Boolean,
+    onVolumeChange: (Int) -> Unit,
+    onSpeechRateChange: (Int) -> Unit,
+    onWarnIfVolumeTooLowChange: (Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 24.dp),
+    ) {
+        SectionHeader(text = stringResource(R.string.tts_settings_title))
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SliderLabel(stringResource(R.string.tts_volume))
+        Slider(
+            value = volume.toFloat(),
+            onValueChange = { onVolumeChange(it.roundToInt()) },
+            valueRange = 0f..maxVolume.coerceAtLeast(1).toFloat(),
+            steps = (maxVolume - 1).coerceAtLeast(0),
+            colors = orangeSliderColors(),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        if (showSpeechRate) {
+            Spacer(modifier = Modifier.height(12.dp))
+            SliderLabel(stringResource(R.string.tts_rate))
             Slider(
-                value = volume.toFloat(),
-                onValueChange = { onVolumeChange(it.roundToInt()) },
-                valueRange = 0f..maxVolume.coerceAtLeast(1).toFloat(),
-                steps = (maxVolume - 1).coerceAtLeast(0),
+                value = speechRate.toFloat(),
+                onValueChange = { onSpeechRateChange(it.roundToInt()) },
+                valueRange = 0f..250f,
                 colors = orangeSliderColors(),
                 modifier = Modifier.fillMaxWidth(),
             )
+        }
 
-            if (showSpeechRate) {
-                Spacer(modifier = Modifier.height(12.dp))
-                SliderLabel(stringResource(R.string.tts_rate))
-                Slider(
-                    value = speechRate.toFloat(),
-                    onValueChange = { onSpeechRateChange(it.roundToInt()) },
-                    valueRange = 0f..250f,
-                    colors = orangeSliderColors(),
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.End
+        ) {
+            SliderLabel(stringResource(R.string.settings_warn_volume_too_low))
+            Spacer(modifier = Modifier.weight(1f))
+            Checkbox(
+                checked = warnIfVolumeTooLow,
+                onCheckedChange = onWarnIfVolumeTooLowChange
+            )
         }
     }
 }
@@ -108,15 +156,17 @@ private fun orangeSliderColors() = SliderDefaults.colors(
 @Composable
 private fun TtsSettingsPreview() {
     YomikataTheme {
-        // ModalBottomSheet ne se rend pas en preview isolée : on prévisualise le contenu.
-        Column(modifier = Modifier.padding(20.dp)) {
-            SectionHeader(text = "Speech settings")
-            Spacer(modifier = Modifier.height(12.dp))
-            SliderLabel("Speech Volume")
-            Slider(value = 0.6f, onValueChange = {}, colors = orangeSliderColors())
-            Spacer(modifier = Modifier.height(12.dp))
-            SliderLabel("Speech rate")
-            Slider(value = 0.4f, onValueChange = {}, colors = orangeSliderColors())
-        }
+        // ModalBottomSheet ne se rend pas en preview isolée : on prévisualise le contenu,
+        // pas le wrapper ModalBottomSheet.
+        TtsSettingsSheetContent(
+            volume = 6,
+            maxVolume = 10,
+            speechRate = 4,
+            warnIfVolumeTooLow = false,
+            showSpeechRate = true,
+            onVolumeChange = {},
+            onSpeechRateChange = {},
+            onWarnIfVolumeTooLowChange = {},
+        )
     }
 }

--- a/app/src/main/kotlin/com/jehutyno/yomikata/util/Prefs.kt
+++ b/app/src/main/kotlin/com/jehutyno/yomikata/util/Prefs.kt
@@ -34,6 +34,10 @@ enum class Prefs(val pref: String) {
     PLAY_START("play_start"),
     PLAY_END("play_end"),
     FONT_SIZE("font_size"),
+    SHOW_MAGNIFIED_WORD("show_magnified_word"),
+    AUTOMATICALLY_CONTINUE("automatically_continue"),
+
+    WARN_VOLUME_TOO_LOW("warn_volume_too_low"),
 
     LAST_SELECTED_LEVEL("last_selected_level"),
 

--- a/app/src/main/res/drawable-notnight/ic_keyboard_double_arrow_right.xml
+++ b/app/src/main/res/drawable-notnight/ic_keyboard_double_arrow_right.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#212121"
+      android:pathData="M383,480L200,296L256,240L496,480L256,720L200,664L383,480ZM647,480L464,296L520,240L760,480L520,720L464,664L647,480Z"/>
+</vector>

--- a/app/src/main/res/drawable-notnight/text_increase.xml
+++ b/app/src/main/res/drawable-notnight/text_increase.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="960"
+        android:viewportHeight="960">
+    <path
+        android:fillColor="#212121"
+        android:pathData="M40,760L250,200L350,200L560,760L464,760L413,617L187,617L136,760L40,760ZM216,536L384,536L302,304L298,304L216,536ZM720,640L720,520L600,520L600,440L720,440L720,320L800,320L800,440L920,440L920,520L800,520L800,640L720,640Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_keyboard_double_arrow_right.xml
+++ b/app/src/main/res/drawable/ic_keyboard_double_arrow_right.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#dcdcdc"
+      android:pathData="M383,480L200,296L256,240L496,480L256,720L200,664L383,480ZM647,480L464,296L520,240L760,480L520,720L464,664L647,480Z"/>
+</vector>

--- a/app/src/main/res/drawable/text_increase.xml
+++ b/app/src/main/res/drawable/text_increase.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="960"
+        android:viewportHeight="960">
+    <path
+        android:fillColor="#dcdcdc"
+        android:pathData="M40,760L250,200L350,200L560,760L464,760L413,617L187,617L136,760L40,760ZM216,536L384,536L302,304L298,304L216,536ZM720,640L720,520L600,520L600,440L720,440L720,320L800,320L800,440L920,440L920,520L800,520L800,640L720,640Z"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -139,6 +139,7 @@
     <string name="prefs_length_message">Anzahl der Wörter pro Sitzung</string>
     <string name="prefs_font_size">Schriftgröße</string>
     <string name="prefs_font_size_message">Schriftgröße der Beispielsätze</string>
+    <string name="prefs_show_magnified_word">Vergrößertes Wort anzeigen</string>
     <string name="app_quit">Möchten Sie Yomikata Z wirklich beenden?</string>
     <string name="tts_settings_title">Spracheinstellungen</string>
     <string name="tts_volume">Sprechlautstärke</string>
@@ -160,6 +161,9 @@
     <string name="settings_play_start_summary">Wort beim Erscheinen abspielen</string>
     <string name="settings_play_end_title">Am Ende abspielen</string>
     <string name="settings_play_end_summary">Wort vor dem Weiterblättern abspielen</string>
+    <string name="settings_automatically_continue_title">Automatisch fortfahren</string>
+    <string name="settings_automatically_continue_summary">Bei richtiger Antwort automatisch fortfahren</string>
+    <string name="settings_warn_volume_too_low">Warnung anzeigen, wenn die Lautstärke zu niedrig ist</string>
     <string name="drawer_home">Start</string>
     <string name="quiz_launched">%1$d Quiz gestartet</string>
     <string name="words_seen">%1$d Wörter gesehen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -139,6 +139,7 @@
     <string name="prefs_length_message">Número de palabras por sesión</string>
     <string name="prefs_font_size">Tamaño de fuente</string>
     <string name="prefs_font_size_message">Tamaño de fuente de las frases de ejemplo</string>
+    <string name="prefs_show_magnified_word">Mostrar la palabra ampliada</string>
     <string name="app_quit">¿Seguro que quieres salir de Yomikata Z?</string>
     <string name="tts_settings_title">Ajustes de voz</string>
     <string name="tts_volume">Volumen de voz</string>
@@ -160,6 +161,9 @@
     <string name="settings_play_start_summary">Reproducir la palabra al aparecer</string>
     <string name="settings_play_end_title">Reproducir al final</string>
     <string name="settings_play_end_summary">Reproducir la palabra antes de avanzar</string>
+    <string name="settings_automatically_continue_title">Continuar automáticamente</string>
+    <string name="settings_automatically_continue_summary">Continuar automáticamente al responder correctamente</string>
+    <string name="settings_warn_volume_too_low">Mostrar aviso cuando el volumen es demasiado bajo</string>
     <string name="drawer_home">Inicio</string>
     <string name="quiz_launched">%1$d cuestionario iniciado</string>
     <string name="words_seen">%1$d palabras vistas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -139,6 +139,7 @@
     <string name="prefs_length_message">Nombre de mots dans une session</string>
     <string name="prefs_font_size">Taille de la police</string>
     <string name="prefs_font_size_message">Taille des phrases d\'exemple</string>
+    <string name="prefs_show_magnified_word">Afficher le mot agrandi</string>
     <string name="app_quit">Etes-vous sur de vouloir quitter Yomikata Z ?</string>
     <string name="tts_settings_title">Paramètres de synthèse vocale</string>
     <string name="tts_volume">Volume d\'élocution</string>
@@ -160,6 +161,9 @@
     <string name="settings_play_start_summary">Ecouter le mot quand il apparait</string>
     <string name="settings_play_end_title">Jouer son à la fin</string>
     <string name="settings_play_end_summary">Ecouter le mot avant de passer au suivant</string>
+    <string name="settings_automatically_continue_title">Continuer automatiquement</string>
+    <string name="settings_automatically_continue_summary">Continuer automatiquement en cas de bonne réponse</string>
+    <string name="settings_warn_volume_too_low">Afficher un avertissement lorsque le volume est trop bas</string>
     <string name="drawer_home">Home</string>
     <string name="quiz_launched">%1$d quizs lancés</string>
     <string name="words_seen">%1$d mots vus</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -139,6 +139,7 @@
     <string name="prefs_length_message">Número de palavras por sessão</string>
     <string name="prefs_font_size">Tamanho da fonte</string>
     <string name="prefs_font_size_message">Tamanho da fonte das frases de exemplo</string>
+    <string name="prefs_show_magnified_word">Mostrar a palavra ampliada</string>
     <string name="app_quit">Tem certeza que deseja sair do Yomikata Z?</string>
     <string name="tts_settings_title">Configurações de voz</string>
     <string name="tts_volume">Volume da voz</string>
@@ -160,6 +161,9 @@
     <string name="settings_play_start_summary">Reproduzir a palavra ao aparecer</string>
     <string name="settings_play_end_title">Reproduzir no final</string>
     <string name="settings_play_end_summary">Reproduzir a palavra antes de avançar</string>
+    <string name="settings_automatically_continue_title">Continuar automaticamente</string>
+    <string name="settings_automatically_continue_summary">Continuar automaticamente ao responder corretamente</string>
+    <string name="settings_warn_volume_too_low">Mostrar aviso quando o volume estiver muito baixo</string>
     <string name="drawer_home">Início</string>
     <string name="quiz_launched">%1$d questionário iniciado</string>
     <string name="words_seen">%1$d palavras vistas</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -139,6 +139,7 @@
     <string name="prefs_length_message">每次会话的单词数量</string>
     <string name="prefs_font_size">字体大小</string>
     <string name="prefs_font_size_message">例句的字体大小</string>
+    <string name="prefs_show_magnified_word">显示放大后的单词</string>
     <string name="app_quit">确定要退出 Yomikata Z 吗？</string>
     <string name="tts_settings_title">语音设置</string>
     <string name="tts_volume">语音音量</string>
@@ -160,6 +161,9 @@
     <string name="settings_play_start_summary">单词出现时播放</string>
     <string name="settings_play_end_title">结束时播放</string>
     <string name="settings_play_end_summary">翻页前播放单词</string>
+    <string name="settings_automatically_continue_title">自动继续</string>
+    <string name="settings_automatically_continue_summary">答对后自动继续</string>
+    <string name="settings_warn_volume_too_low">音量过低时显示警告</string>
     <string name="drawer_home">首页</string>
     <string name="quiz_launched">已启动 %1$d 个测验</string>
     <string name="words_seen">已看 %1$d 个单词</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,6 +169,7 @@
     <string name="prefs_speed_message">How many correct answers to level up</string>
     <string name="prefs_font_size">Font size</string>
     <string name="prefs_font_size_message">Size of example sentences</string>
+    <string name="prefs_show_magnified_word">Show magnified word</string>
     <string name="prefs_length_title">Sessions length</string>
     <string name="prefs_length_message">Number of words in a session</string>
     <string name="app_quit">Are you sure you want to quit Yomikata Z?</string>
@@ -193,6 +194,9 @@
     <string name="settings_play_start_summary">Play word when it appears</string>
     <string name="settings_play_end_title">Play at end</string>
     <string name="settings_play_end_summary">Play word before going to next</string>
+    <string name="settings_automatically_continue_title">Automatically continue</string>
+    <string name="settings_automatically_continue_summary">Automatically continue on correct answer</string>
+    <string name="settings_warn_volume_too_low">Show warning when volume is too low</string>
     <string name="drawer_home">Home</string>
     <string name="quiz_launched">%1$d quizzes launched</string>
     <string name="words_seen">%1$d words seen</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -12,6 +12,12 @@
             android:title="@string/prefs_font_size"/>
 
         <CheckBoxPreference
+            android:defaultValue="true"
+            android:icon="@drawable/text_increase"
+            android:key="show_magnified_word"
+            android:title="@string/prefs_show_magnified_word"/>
+
+        <CheckBoxPreference
             android:defaultValue="false"
             android:icon="@drawable/ic_keyboard"
             android:key="input_change"
@@ -57,6 +63,13 @@
             android:key="play_end"
             android:summary="@string/settings_play_end_summary"
             android:title="@string/settings_play_end_title"/>
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:icon="@drawable/ic_keyboard_double_arrow_right"
+            android:key="automatically_continue"
+            android:title="@string/settings_automatically_continue_title"
+            android:summary="@string/settings_automatically_continue_summary"/>
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Fix quiz keyboard show/hide for text input questions. Fix quiz keyboard input forcing qwerty layout.
Fix quiz text input box not being focused.
Fix font size selection not being applied to quiz sentence.

Add show/hide magnified word option for quiz.
Add toggle for warning toast about volume being too low for TTS.
Add toggle for automatically advancing quiz on correct answer.